### PR TITLE
Feat: 답변상태 Badge 컴포넌트 개발

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -1,0 +1,35 @@
+import styles from "./Badge.module.css";
+
+export function Badge({ status }) {
+  const badgeData = {
+    completed: {
+      label: "답변 완료",
+      color: "var(--color-primary-400)",
+      borderColor: "var(--color-primary-400)",
+    },
+    incomplete: {
+      label: "미답변",
+      color: "var(--color-gray-400)",
+      borderColor: "var(--color-gray-400)",
+    },
+  };
+
+  const badge = badgeData[status];
+  if (!badge) {
+    return null;
+  }
+
+  return (
+    <div>
+      <span
+        className={styles.badge}
+        style={{
+          color: badge.color,
+          borderColor: badge.borderColor,
+        }}
+      >
+        {badge.label}
+      </span>
+    </div>
+  );
+}

--- a/src/components/Badge/Badge.module.css
+++ b/src/components/Badge/Badge.module.css
@@ -1,0 +1,12 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 1.2rem;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  border-style: solid;
+  border-width: 0.1rem;
+  border-radius: var(--border-radius-md);
+  white-space: nowrap;
+}

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -1,0 +1,1 @@
+export * from "./Badge";

--- a/src/pages/sample/components/SolSample.jsx
+++ b/src/pages/sample/components/SolSample.jsx
@@ -1,3 +1,20 @@
+import { Badge } from "@components/Badge";
+
 export default function SolSample() {
-  return <div>SolSample</div>;
+  const answer = [
+    {
+      id: 6969,
+      questionId: 15356,
+      content: "답변해드려요",
+      isRejected: false,
+      createdAt: "2024-12-09T13:11:31.525185Z",
+    },
+  ];
+
+  const status = answer && !answer.isRejected ? "completed" : "incomplete";
+  return (
+    <>
+      <Badge status={status} />
+    </>
+  );
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #31 

## 📝 작업 내용
- 답변 상태 뱃지 컴포넌트 (답변 완료/미답변)

## 📸 결과물
![image](https://github.com/user-attachments/assets/5321052b-ec2a-4afc-bd84-b7ae406f383b)
![image](https://github.com/user-attachments/assets/67411059-59f5-4e9e-bb4a-cd99d5ed004e)
![image](https://github.com/user-attachments/assets/2726bfd6-6cc6-4904-aa0c-d6d2932e0c2c)
![image](https://github.com/user-attachments/assets/e5fbba34-6f81-4df2-bf7c-6ee194c985dd)

## 👩‍💻 공유 포인트 및 논의 사항
- answer변수에 api를 통해 들어오는 데이터 형식 그대로를 담았습니다. (예시코드)
- status에 completed(답변 완료), incomplete(미답변) 상태 값을 보냅니다.
- status 값에 따라 badgeData 변수에 저장된 라벨명, 색상코드 값들이 출력 됩니다.
