### PR TITLE
Feat(#28): reaction 컴포넌트 추가

### DIFF
--- a/src/components/Reaction/Reaction.jsx
+++ b/src/components/Reaction/Reaction.jsx
@@ -1,0 +1,60 @@
+import clsx from "clsx";
+import { Icon } from "@components/Icon";
+import styles from "./Reaction.module.css";
+
+/**
+ * Reaction 버튼 컴포넌트
+ * 
+ * 좋아요와 싫어요 버튼을 생성합니다. 
+ * 카운트 값에 따라 버튼과 아이콘의 색상이 변합니다.
+ * 
+ * 좋아요 (like) : 카운트가 1 이상이면 파란색
+ * 싫어요 (dislike):  카운트가 1 이상이면 검은색
+ * 비활성화된 경우 색상은 회색
+ * 
+ * @param {object} props
+ * @param {string} props.type - 버튼 유형 ("like" | "dislike")
+ * @param {number} props.count - 카운트 숫자
+ * @param {boolean} props.disabled - 버튼 비활성화 여부
+ *
+ * @returns {JSX.Element} - 좋아요 또는 싫어요 버튼 컴포넌트
+ *
+
+ * @example
+ * //기본 사용법
+ * <Reaction type="like" count={16} />
+ *
+ * //onClick 핸들러 추가 가능
+ * //(기본적인 button의 props는 다 받을수 있어요)
+ * <Reaction type="dislike" count={16} onClick={() => console.log('싫어요 클릭')} />
+ *
+ * //버튼 비활성
+ * <Reaction type="dislike" count={0} disabled />
+ */
+
+export function Reaction({ type = "like", count = 0, disabled, ...props }) {
+  const isActive = count > 0;
+  const buttonCss = clsx(
+    styles.button,
+    type === "like" ? styles.like : styles.dislike,
+    isActive && styles.active,
+    disabled && styles.disabled,
+  );
+  const iconName = type === "like" ? "thumbsUp" : "thumbsDown";
+  const text = type === "like" ? "좋아요" : "싫어요";
+
+  let iconColor = "gray-400";
+  if (isActive && !disabled) {
+    iconColor = type === "like" ? "blue" : "black";
+  }
+
+  return (
+    <button type="button" className={buttonCss} disabled={disabled} {...props}>
+      <Icon size={16} color={iconColor} name={iconName} className={styles.icon} />
+      <div className={styles.label}>
+        <span className={styles.title}>{text}</span>
+        {count ? <span className={styles.count}>{count}</span> : ""}
+      </div>
+    </button>
+  );
+}

--- a/src/components/Reaction/Reaction.module.css
+++ b/src/components/Reaction/Reaction.module.css
@@ -1,0 +1,89 @@
+.button {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-6);
+  height: 2.4rem;
+  border-radius: var(--border-radius-md);
+  color: var(--color-gray-400);
+}
+
+.button:after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: calc(100% + 1em);
+  height: calc(100% + 0.3em);
+  transform: translate(-50%, -50%) scale(0);
+  border-radius: var(--border-radius-md);
+  background: var(--color-gray-200);
+  opacity: 0;
+  transition: transform ease-in-out 0.1s;
+}
+
+.button:not(:disabled):active {
+  transform: scale(0.98);
+}
+
+.button:not(:disabled):hover:after {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.icon {
+  position: relative;
+  z-index: 1;
+  transform-origin: center bottom;
+}
+
+.button:not(:disabled):hover .icon {
+  animation: shake 0.6s ease;
+}
+
+.label {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.active,
+.active.like {
+  color: var(--color-blue);
+}
+
+.active.dislike {
+  color: var(--color-black);
+}
+
+.button:disabled,
+.button.disabled {
+  opacity: 0.2;
+  cursor: not-allowed;
+  color: var(--color-gray-400);
+}
+
+@keyframes shake {
+  0% {
+    transform: rotate(0deg);
+  }
+  20% {
+    transform: rotate(-15deg);
+  }
+  40% {
+    transform: rotate(15deg);
+  }
+  60% {
+    transform: rotate(-10deg);
+  }
+  80% {
+    transform: rotate(10deg);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
+}

--- a/src/components/Reaction/index.js
+++ b/src/components/Reaction/index.js
@@ -1,0 +1,1 @@
+export * from "./Reaction";

--- a/src/pages/sample/components/ChankiSample.jsx
+++ b/src/pages/sample/components/ChankiSample.jsx
@@ -1,9 +1,26 @@
 import { Icon } from "@components/Icon";
+import { Reaction } from "@components/Reaction";
 import styles from "./ChankiSample.module.css";
 
 export default function ChankiSample() {
   return (
     <div>
+      <div className={styles.flex}>
+        <Reaction type="like" count={0} />
+        <Reaction type="dislike" count={0} />
+      </div>
+      <div className={styles.flex}>
+        <Reaction type="like" count={16} />
+        <Reaction type="dislike" count={0} />
+      </div>
+      <div className={styles.flex}>
+        <Reaction type="like" count={0} />
+        <Reaction type="dislike" count={6} />
+      </div>
+      <div className={styles.flex}>
+        <Reaction type="like" count={0} disabled />
+        <Reaction type="dislike" count={6} disabled />
+      </div>
       <div className={styles.flex}>
         <Icon />
         <Icon name="arrowDown" />

--- a/src/pages/sample/components/ChankiSample.module.css
+++ b/src/pages/sample/components/ChankiSample.module.css
@@ -1,5 +1,6 @@
 .flex {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 2rem;
+  margin-bottom: 2rem;
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #28 

## 📝 작업 내용
- 좋아요, 싫어요 버튼 컴포넌트 작업했습니다.
- 좋아요, 싫어요 버튼은 카운트가 1이상이면 각각의 색상으로 활성화 상태를 나타냈습니다.
- 기본적인 button의 props도 전달받을수 있게 작업했습니다.
- 버튼에 hover시 엄지가 흔들리는 keyframe 애니메이션 추가했어요

## 📸 결과물

https://github.com/user-attachments/assets/9dba8cf7-2914-4369-9a0f-124b22682026



## 👩‍💻 공유 포인트 및 논의 사항
- 좋아요 버튼, 싫어요 버튼을 마구마구 누르면 계속 각각 카운트가 올라가는게 맞는것 같아요. (익명이라)
- 위 내용은 나중에 페이지 작업할때 또 의논해보면 좋을것 같아요
- 그저 좋아요버튼의 파란색과, 싫어요 버튼의 검은색은 카운트가 1이상이냐에만 초점을 뒀습니다.