### PR TITLE
Feat(#36): 공통 컴포넌트 - 모달 개발 (SOL)

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,0 +1,40 @@
+import { Icon } from "@components/Icon";
+import styles from "./Modal.module.css";
+
+/**
+ * @param {object} props
+ * @param {function} props.handleToggleModal - 모달 토글 (열기/닫기)
+ * @param {string} props.title - 모달 타이틀
+ * @param {string} props.icon - 모달 아이콘명
+ * @param {children} props.children - 모달 콘텐츠
+ */
+
+export function Modal({ handleToggleModal, title, icon, children }) {
+  if (!handleToggleModal) return null;
+
+  return (
+    <>
+      <div className={styles["modal-overlay"]} onClick={handleToggleModal}>
+        <div
+          className={styles["modal-container"]}
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          <div className={styles["modal-header"]}>
+            {icon && (
+              <div className={styles["modal-image"]}>
+                <Icon name={icon} />
+              </div>
+            )}
+            {title && <div className={styles["modal-title"]}>{title}</div>}
+            <button className={styles["modal-close-btn"]} onClick={handleToggleModal}>
+              <Icon name="close" />
+            </button>
+          </div>
+          <div className={styles["modal-content"]}>{children}</div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -1,0 +1,54 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  padding: 2.3rem;
+  background-color: rgba(0, 0, 0, 0.56);
+  z-index: 999;
+}
+
+.modal-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 612px;
+  max-height: calc(100vh - 4.6rem);
+  padding: 4rem 4rem 7rem;
+  border-radius: 2.4rem;
+  background: #fff;
+  box-shadow: var(--shadow-300);
+  overflow: hidden;
+}
+
+.modal-header {
+  position: relative;
+  display: flex;
+  gap: 0.8rem;
+  padding-bottom: 40px;
+}
+
+.modal-title {
+  font-size: var(--font-size-h3);
+}
+
+.modal-close-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transition: ease-out 0.3s all;
+}
+
+.modal-close-btn:hover {
+  transform: rotate(90deg);
+  stroke-width: 5;
+}
+
+.modal-content {
+  flex-grow: 1;
+  overflow-y: auto;
+}

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,0 +1,1 @@
+export * from "./Modal";

--- a/src/components/Modal/usePreventScroll.js
+++ b/src/components/Modal/usePreventScroll.js
@@ -1,0 +1,34 @@
+import { useState } from "react";
+
+/**
+ * 스크롤 방지와 현재 스크롤 위치를 반환하는 custom hook
+ * 스크롤 막기 함수
+ * @function preventScroll
+ * 스크롤 원래 상태로 되돌리는 함수 (스크롤 막기 해제)
+ * @function allowScroll
+ */
+const usePreventScroll = () => {
+  const [prevScrollY, setPrevScrollY] = useState(0);
+
+  const preventScroll = () => {
+    const currentScrollY = window.scrollY;
+    setPrevScrollY(currentScrollY); // 이전 스크롤 위치를 상태로 저장
+
+    document.body.style.position = "fixed";
+    document.body.style.width = "100%";
+    document.body.style.top = `-${currentScrollY}px`; // 현재 스크롤 위치
+    document.body.style.overflowY = "hidden";
+  };
+
+  const allowScroll = () => {
+    document.body.style.position = "";
+    document.body.style.width = "";
+    document.body.style.top = "";
+    document.body.style.overflowY = "";
+    window.scrollTo(0, prevScrollY); // 이전 스크롤 위치로 이동
+  };
+
+  return { preventScroll, allowScroll };
+};
+
+export default usePreventScroll;

--- a/src/pages/sample/components/SolSample.jsx
+++ b/src/pages/sample/components/SolSample.jsx
@@ -1,6 +1,12 @@
+import { useState } from "react";
 import { Badge } from "@components/Badge";
+import { Modal } from "@components/Modal";
+import usePreventScroll from "@components/Modal/usePreventScroll";
 
 export default function SolSample() {
+  /**
+   * 답변 상태 뱃지
+   */
   const answer = [
     {
       id: 6969,
@@ -12,9 +18,41 @@ export default function SolSample() {
   ];
 
   const status = answer && !answer.isRejected ? "completed" : "incomplete";
+
+  /**
+   * 모달창
+   */
+  const [isModal, setIsModal] = useState(false);
+  const { preventScroll, allowScroll } = usePreventScroll();
+
+  const handleToggleModal = () => {
+    setIsModal(!isModal);
+    isModal ? allowScroll() : preventScroll();
+  };
+
   return (
     <>
+      {/* 답변 상태 뱃지 */}
       <Badge status={status} />
+
+      {/* 모달창 */}
+      <button onClick={handleToggleModal}>모달 열기</button>
+      {isModal && (
+        <Modal handleToggleModal={handleToggleModal} title="질문을 작성하세요" icon="message">
+          <p>To. 😸 아초는고양이</p>
+          <div
+            style={{
+              width: "100%",
+              height: "300px",
+              marginTop: "15px",
+              padding: "20px",
+              backgroundColor: "#f9f9f9",
+            }}
+          >
+            질문을 입력해주세요
+          </div>
+        </Modal>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #36

## 📝 작업 내용
- 모달 마크업
- 모달 닫기/열기 기능 구현
- 모달창 열렸을 때 스크롤 막기 구현

## 📸 결과물
- pc
![image](https://github.com/user-attachments/assets/421fa6d1-3fad-435d-80ab-4a1d1e69cdae)
- mobile
![image](https://github.com/user-attachments/assets/ecf9af83-ac1b-4355-a3aa-71d33f37666c)


## 👩‍💻 공유 포인트 및 논의 사항
- 모달 아이콘과 모달 타이틀을 넘겨주지 않으면 모달창 상단에 닫기 버튼만 보입니다.
- 모달창 닫기 이벤트는 모달창 외부 클릭과 닫기 버튼 클릭 두 곳에서 일어납니다.
- 브라우저 크기에 비해 모달창 콘텐츠가 넘칠 경우에는 내부 스크롤이 생성되도록 스타일 잡았습니다.
-  모달창이 열릴 때 브라우저 전체 스크롤을 막고 닫힐 때 스크롤이 원래 위치로 복구 됩니다.
   - 스크롤 막기/해제 부분은 usePreventScroll.js에 커스텀 훅으로 빼놓았습니다.
   - 다른 페이지에서도 활용 가능합니다.