### PR TITLE
Fix(#60): avatar 컴포넌트에 src가 누락됬을경우에도 기본 이미지가 나오게 설정

### DIFF
--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -31,9 +31,11 @@ export function Avatar({ src, alt = "", size }) {
     e.target.src = defaultAvatar;
   }
 
+  const imgSrc = src || defaultAvatar;
+
   return (
     <figure className={styles.cover} style={coverStyle}>
-      <img className={styles.img} src={src} alt={alt} onError={handleError} />
+      <img className={styles.img} src={imgSrc} alt={alt} onError={handleError} />
     </figure>
   );
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #60 

## 📝 작업 내용
 avatar 컴포넌트에 기본 이미지가 나오는 케이스들을 점검하고 추가했습니다.
- src를 누락한경우
- src에 빈문자를 전달한경우
- src의 주소로 이미지를 불러오는데 실패한 경우

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
