### PR TITLE
Feat(#64): PostDetail loader 추가

### DIFF
--- a/src/pages/post/components/PostDetailHeader.jsx
+++ b/src/pages/post/components/PostDetailHeader.jsx
@@ -1,6 +1,11 @@
+import { useLoaderData } from "react-router-dom";
 import styles from "./PostDetailHeader.module.css";
 
 export default function PostDetailHeader() {
+  //const data = useLoaderData(); // 이렇게 쓰셔도 되고, 분해하셔도 되욤
+  const { name, imageSource } = useLoaderData();
+  console.log(name);
+
   return (
     <div className={styles.container}>
       PostDetailHeader : 한솔님 작업구역 (답변, 질문페이지 공통헤더)

--- a/src/pages/post/loader/PostDetailLoader.js
+++ b/src/pages/post/loader/PostDetailLoader.js
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+export async function loader() {
+  // TODO : api 추상화 되면 교체예정
+  const res = await axios.get("https://openmind-api.vercel.app/12-2/subjects/9281/");
+  const { data } = res;
+  return data;
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -8,6 +8,7 @@ import PostAnswerPage from "./pages/post/PostAnswerPage";
 import SamplePage from "./pages/sample/SamplePage";
 import PostDetailLayout from "./pages/post/components/PostDetailLayout";
 import PostListLayout from "./pages/post/components/PostListLayout";
+import { loader as PostDetailLoader } from "./pages/post/loader/PostDetailLoader";
 
 export const router = createBrowserRouter([
   {
@@ -25,8 +26,12 @@ export const router = createBrowserRouter([
         children: [{ index: true, element: <PostListPage /> }],
       },
       {
+        id: "post",
         path: "/post",
         element: <PostDetailLayout />,
+        loader: PostDetailLoader,
+        //TODO : fallback ui 작업
+        hydrateFallbackElement: <div>피드 정보를 가져오는 중입니다...</div>,
         children: [
           {
             path: ":id",


### PR DESCRIPTION
## #️⃣ 이슈

- close #64

## 📝 작업 내용
아래 페이지에서 공유하게 될 피드 정보 데이터를 react router의 loader로 받아서
useLoaderData, useRouteLoaderData 훅을 통해서 사용할수 있습니다.

- 한솔님이 작업하시는 헤더 파일안에서 const data = useLoaderData(); 이렇게 사용해서 데이터를 가져오면 됩니다.
- 원리는 react router의 loader입니다.
- '/post' 주소를 타고갈때, loader를 실행해서 데이터를 미리받아서 주입시켜주는 원리입니다.
- loader함수에는 방정보를 가져오는 api 호출이 담겨있고, 나중에 유섭님이 api 추상화 완료하시면 교체할께요
- loader가 가져온 데이터를 useLoaderData라는 함수로 가져와서 쓰는 방식입니다. (약간 context api같은 느낌이욤)
- useLoaderData는 react router의 훅입니당

## 📸 결과물
![image](https://github.com/user-attachments/assets/4c94c34a-1973-468e-a346-4cca3fc4dad0)

## 👩‍💻 공유 포인트 및 논의 사항
