### PR TITLE
Feat(#62) feed card 컴포넌트 작업

### DIFF
--- a/src/components/FeedCard/Answer.jsx
+++ b/src/components/FeedCard/Answer.jsx
@@ -1,0 +1,38 @@
+import { AnswerForm } from "@components/FeedCard";
+import { Avatar } from "@components/Avatar";
+import { fromNow } from "@util/format";
+import styles from "./Answer.module.css";
+
+export function Answer({ answer, user, mode, isEdit, onCreate, onUpdate, onCancel }) {
+  const { createdAt, isRejected, content } = answer || {};
+  const { name, imageSource } = user;
+  const isEditMode = mode === "answer" && isEdit;
+
+  if (!answer && mode === "view") {
+    return null;
+  }
+
+  let answerContent;
+  if (isEditMode) {
+    answerContent = <AnswerForm initialValue={content} onSubmit={onUpdate} onCancel={onCancel} />;
+  } else {
+    answerContent = content ? content : <AnswerForm onSubmit={onCreate} />;
+  }
+
+  return (
+    <div className={styles.answer}>
+      <div className={styles.profile}>
+        <Avatar src={imageSource} alt={name} />
+      </div>
+      <div className={styles.detail}>
+        <div className={styles.meta}>
+          <span className={styles.name}>{name}</span>
+          {createdAt && <span className={styles.date}>{fromNow(createdAt)}</span>}
+        </div>
+        <div className={styles.content}>
+          {isRejected ? <div className={styles.reject}>답변 거절</div> : answerContent}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FeedCard/Answer.module.css
+++ b/src/components/FeedCard/Answer.module.css
@@ -6,6 +6,10 @@
 .answer .profile {
   width: 4.8rem;
   flex: 0 0 auto;
+
+  @media (width < 768px) {
+    width: 3.2rem;
+  }
 }
 
 .answer .meta {
@@ -19,6 +23,10 @@
   flex: 1;
   min-width: 0;
   padding-top: 0.6rem;
+
+  @media (width < 768px) {
+    padding-top: 0.2rem;
+  }
 }
 
 .answer .name {

--- a/src/components/FeedCard/Answer.module.css
+++ b/src/components/FeedCard/Answer.module.css
@@ -1,0 +1,48 @@
+.answer {
+  display: flex;
+  gap: var(--spacing-12);
+}
+
+.answer .profile {
+  width: 4.8rem;
+  flex: 0 0 auto;
+}
+
+.answer .meta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-8);
+  margin-bottom: var(--spacing-8);
+}
+
+.answer .detail {
+  flex: 1;
+  min-width: 0;
+  padding-top: 0.6rem;
+}
+
+.answer .name {
+  font-size: var(--font-size-lg);
+  color: var(--color-black);
+}
+
+.answer .date {
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-400);
+}
+
+.answer .content {
+  font-size: var(--font-size-md);
+  color: var(--color-black);
+  line-height: 1.375;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
+.answer textarea {
+  line-height: 1.3;
+}
+
+.answer .reject {
+  color: var(--color-red);
+}

--- a/src/components/FeedCard/AnswerForm.jsx
+++ b/src/components/FeedCard/AnswerForm.jsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { InputTextarea } from "@components/Input";
+import styles from "./AnswerForm.module.css";
+
+export function AnswerForm({ initialValue = "", onSubmit, onCancel }) {
+  const [value, setValue] = useState(initialValue);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    onSubmit(value);
+  }
+
+  function handleReset() {
+    setValue(initialValue);
+    onCancel();
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <InputTextarea
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="답변을 입력해주세요"
+      />
+      <button type="submit" className={styles.button} disabled={!value}>
+        {initialValue ? "수정" : "작성"}
+      </button>
+      <button type="button" onClick={handleReset} className={styles.reset}>
+        취소
+      </button>
+    </form>
+  );
+}

--- a/src/components/FeedCard/AnswerForm.module.css
+++ b/src/components/FeedCard/AnswerForm.module.css
@@ -1,0 +1,22 @@
+.button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 4.6rem;
+  border-radius: var(--border-radius-md);
+  background: var(--color-primary-400);
+  color: var(--color-white);
+}
+
+.button:disabled {
+  background: var(--color-primary-300);
+}
+
+.reset {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 4.6rem;
+}

--- a/src/components/FeedCard/FeedCard.jsx
+++ b/src/components/FeedCard/FeedCard.jsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { MoreMenu, Reaction } from "@components/ui";
+import { Question, Answer, Reactions, FeedCardWrapper } from "@components/FeedCard";
+
+export function FeedCard({
+  question,
+  mode,
+  feedOwner,
+  onUpdate,
+  onCreate,
+  onDelete,
+  onReject,
+  onLike,
+  onDislike,
+}) {
+  const { content, like, dislike, createAt, answer } = question;
+  const [isEdit, setIsEdit] = useState(false);
+
+  function handleModify() {
+    setIsEdit(true);
+  }
+
+  function handleCancel() {
+    setIsEdit(false);
+  }
+
+  return (
+    <FeedCardWrapper>
+      <Question status={!!answer} createAt={createAt} content={content}>
+        {mode === "answer" && (
+          <MoreMenu>
+            <MoreMenu.Item icon="reject" onClick={onReject}>
+              거절하기
+            </MoreMenu.Item>
+            <MoreMenu.Item icon="edit" onClick={handleModify}>
+              수정하기
+            </MoreMenu.Item>
+            <MoreMenu.Item icon="close" onClick={onDelete}>
+              삭제하기
+            </MoreMenu.Item>
+          </MoreMenu>
+        )}
+      </Question>
+      <Answer
+        answer={answer}
+        user={feedOwner}
+        mode={mode}
+        isEdit={isEdit}
+        onCreate={onCreate}
+        onUpdate={onUpdate}
+        onCancel={handleCancel}
+      />
+      <Reactions>
+        <Reaction type="like" count={like} onClick={onLike} />
+        <Reaction type="dislike" count={dislike} onClick={onDislike} />
+      </Reactions>
+    </FeedCardWrapper>
+  );
+}

--- a/src/components/FeedCard/FeedCardWrapper.jsx
+++ b/src/components/FeedCard/FeedCardWrapper.jsx
@@ -1,0 +1,5 @@
+import styles from "./FeedCardWrapper.module.css";
+
+export function FeedCardWrapper({ children }) {
+  return <div className={styles.card}>{children}</div>;
+}

--- a/src/components/FeedCard/FeedCardWrapper.module.css
+++ b/src/components/FeedCard/FeedCardWrapper.module.css
@@ -1,0 +1,5 @@
+.card {
+  padding: 3.2rem;
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-100);
+}

--- a/src/components/FeedCard/Question.jsx
+++ b/src/components/FeedCard/Question.jsx
@@ -1,0 +1,18 @@
+import { Badge } from "@components/ui";
+import { fromNow } from "@util/format";
+import styles from "./Question.module.css";
+
+export function Question({ status, createAt, content, children }) {
+  return (
+    <>
+      <header className={styles.header}>
+        <Badge status={status ? "completed" : "incomplete"} />
+        {children}
+      </header>
+      <div className={styles.question}>
+        <div className={styles.meta}>질문 · {fromNow(createAt)}</div>
+        <h3 className={styles.title}>{content}</h3>
+      </div>
+    </>
+  );
+}

--- a/src/components/FeedCard/Question.module.css
+++ b/src/components/FeedCard/Question.module.css
@@ -1,0 +1,24 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-24);
+}
+
+.question {
+  margin-bottom: var(--spacing-32);
+}
+
+.question .meta {
+  margin-bottom: var(--spacing-6);
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-400);
+}
+
+.question .title {
+  font-size: var(--font-size-lg);
+  color: var(--color-black);
+  line-height: 1.2;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}

--- a/src/components/FeedCard/Reactions.jsx
+++ b/src/components/FeedCard/Reactions.jsx
@@ -1,0 +1,5 @@
+import styles from "./Reactions.module.css";
+
+export function Reactions({ children }) {
+  return <footer className={styles.footer}>{children}</footer>;
+}

--- a/src/components/FeedCard/Reactions.module.css
+++ b/src/components/FeedCard/Reactions.module.css
@@ -1,0 +1,8 @@
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-24);
+  padding-top: var(--spacing-32);
+  margin-top: var(--spacing-24);
+  border-top: 1px solid var(--color-gray-300);
+}

--- a/src/components/FeedCard/index.js
+++ b/src/components/FeedCard/index.js
@@ -1,0 +1,6 @@
+export * from "./FeedCard";
+export * from "./Answer";
+export * from "./AnswerForm";
+export * from "./FeedCardWrapper";
+export * from "./Question";
+export * from "./Reactions";

--- a/src/pages/sample/components/ChankiSample.jsx
+++ b/src/pages/sample/components/ChankiSample.jsx
@@ -1,10 +1,31 @@
 import { useState } from "react";
 import styles from "./ChankiSample.module.css";
 import { MoreMenu, Select, Avatar, Reaction, Icon } from "@components/ui";
-// import { Icon } from "@components/Icon";
-// import { Reaction } from "@components/Reaction";
-// import { Avatar } from "@components/Avatar/Avatar";
-// import { MoreMenu, Select } from "@components/Dropdown";
+import { FeedCard } from "@components/FeedCard";
+
+const fakeQuestion = {
+  id: 15382,
+  subjectId: 9281,
+  content: "히히히호호호",
+  like: 2,
+  dislike: 2,
+  createdAt: "2024-12-12T14:00:03.343827Z",
+  answer: {
+    id: 6976,
+    questionId: 15382,
+    content: "웃기냐고",
+    isRejected: false,
+    createdAt: "2024-12-12T14:00:17.802338Z",
+  },
+};
+const fakeUser = {
+  id: 9281,
+  name: "test",
+  imageSource:
+    "https://fastly.picsum.photos/id/502/200/200.jpg?hmac=c6mcZ5mcmjadIeDKaJClpvPz9R9-X9q6c0Un-n73Kv4",
+  questionCount: 14,
+  createdAt: "2024-12-09T12:56:20.283029Z",
+};
 
 export default function ChankiSample() {
   const [formData, setFormData] = useState({
@@ -12,8 +33,22 @@ export default function ChankiSample() {
     region: "seoul",
     content: "",
   });
+
   return (
     <div>
+      <div className={styles.feedCards}>
+        <FeedCard
+          question={fakeQuestion}
+          feedOwner={fakeUser}
+          mode="answer"
+          onUpdate={() => alert("답변을 수정한다!!!")}
+          onCreate={() => alert("답변을 작성한다!!!")}
+          onDelete={() => alert("답변을 지운다!!!")}
+          onReject={() => alert("거절한닷!!!")}
+          onLike={() => alert("좋아욧!!!")}
+          onDislike={() => alert("싫어욧!!!")}
+        />
+      </div>
       <div className={styles.flex}>
         <MoreMenu>
           <MoreMenu.Item onClick={() => alert("hi")} icon="edit">

--- a/src/pages/sample/components/ChankiSample.jsx
+++ b/src/pages/sample/components/ChankiSample.jsx
@@ -3,7 +3,7 @@ import styles from "./ChankiSample.module.css";
 import { MoreMenu, Select, Avatar, Reaction, Icon } from "@components/ui";
 import { FeedCard } from "@components/FeedCard";
 
-const fakeQuestion = {
+const fakeQuestion1 = {
   id: 15382,
   subjectId: 9281,
   content: "히히히호호호",
@@ -18,6 +18,16 @@ const fakeQuestion = {
     createdAt: "2024-12-12T14:00:17.802338Z",
   },
 };
+
+const fakeQuestion2 = {
+  id: 15382,
+  subjectId: 9281,
+  content: "히히히호호호",
+  like: 2,
+  dislike: 2,
+  createdAt: "2024-12-12T14:00:03.343827Z",
+};
+
 const fakeUser = {
   id: 9281,
   name: "test",
@@ -38,7 +48,42 @@ export default function ChankiSample() {
     <div>
       <div className={styles.feedCards}>
         <FeedCard
-          question={fakeQuestion}
+          question={fakeQuestion1}
+          feedOwner={fakeUser}
+          mode="view"
+          onUpdate={() => alert("답변을 수정한다!!!")}
+          onCreate={() => alert("답변을 작성한다!!!")}
+          onDelete={() => alert("답변을 지운다!!!")}
+          onReject={() => alert("거절한닷!!!")}
+          onLike={() => alert("좋아욧!!!")}
+          onDislike={() => alert("싫어욧!!!")}
+        />
+        <FeedCard
+          question={fakeQuestion2}
+          feedOwner={fakeUser}
+          mode="view"
+          onUpdate={() => alert("답변을 수정한다!!!")}
+          onCreate={() => alert("답변을 작성한다!!!")}
+          onDelete={() => alert("답변을 지운다!!!")}
+          onReject={() => alert("거절한닷!!!")}
+          onLike={() => alert("좋아욧!!!")}
+          onDislike={() => alert("싫어욧!!!")}
+        />
+      </div>
+      <div className={styles.feedCards}>
+        <FeedCard
+          question={fakeQuestion1}
+          feedOwner={fakeUser}
+          mode="answer"
+          onUpdate={() => alert("답변을 수정한다!!!")}
+          onCreate={() => alert("답변을 작성한다!!!")}
+          onDelete={() => alert("답변을 지운다!!!")}
+          onReject={() => alert("거절한닷!!!")}
+          onLike={() => alert("좋아욧!!!")}
+          onDislike={() => alert("싫어욧!!!")}
+        />
+        <FeedCard
+          question={fakeQuestion2}
           feedOwner={fakeUser}
           mode="answer"
           onUpdate={() => alert("답변을 수정한다!!!")}

--- a/src/pages/sample/components/ChankiSample.module.css
+++ b/src/pages/sample/components/ChankiSample.module.css
@@ -4,3 +4,14 @@
   gap: 2rem;
   margin-bottom: 2rem;
 }
+
+.feedCards {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+  margin-bottom: 2rem;
+}
+
+.feedCards > div {
+  width: 100%;
+}

--- a/src/util/format.js
+++ b/src/util/format.js
@@ -1,0 +1,10 @@
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import "dayjs/locale/ko";
+
+dayjs.extend(relativeTime);
+dayjs.locale("ko");
+
+export function fromNow(date) {
+  return dayjs(date).fromNow();
+}


### PR DESCRIPTION
## #️⃣ 이슈

- close #62 

## 📝 작업 내용
- 피드 상세페이지에서 사용되는 질문카드를 작업했습니다.
- 질문카드 내부에 들어가는 컴포넌트들을 분리해서 작업했습니다.
  - 카드 외형 컴포넌트 (카드 껍데기, 카드 푸터 껍데기)
  - 상단 질문 컴포넌트
  - 답변자 정보 컴포넌트
  - 답변 컴포넌트
  - 답변 입력/수정 컴포넌트

## 📸 결과물
![image](https://github.com/user-attachments/assets/3fc12f95-5ba2-45a7-bb49-94d9ed6eb61c)

## 👩‍💻 공유 포인트 및 논의 사항
버튼 공용컴포넌트가 완성되면 교체 예정입니다. 
임시로 css작업해두었어요