### PR TITLE
Feat(#77): 메인로고 컴포넌트 반응형 구현

### DIFF
--- a/src/pages/main/MainPage.jsx
+++ b/src/pages/main/MainPage.jsx
@@ -1,14 +1,15 @@
-import Lottie from "react-lottie";
-import LogoLottie from "@assets/img/common/logo.json";
+// import Lottie from "react-lottie";
+// import LogoLottie from "@assets/img/common/logo.json";
 import styles from "./MainPage.module.css";
+import MainLogo from "./components/MainLogo";
 
 export default function MainPage() {
   return (
     <div className={styles.container}>
-      MainPage : 기연님 작업페이지
-      <div>
+      <MainLogo />
+      {/* <div>
         <Lottie options={{ loop: true, autoplay: true, animationData: LogoLottie }} />
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/src/pages/main/MainPage.module.css
+++ b/src/pages/main/MainPage.module.css
@@ -1,5 +1,0 @@
-.container {
-  border: 10px solid green;
-  min-height: 100vh;
-  padding: 20px;
-}

--- a/src/pages/main/components/MainLogo.jsx
+++ b/src/pages/main/components/MainLogo.jsx
@@ -1,0 +1,10 @@
+import MainLogoImg from "/src/assets/img/common/logo.svg";
+import styles from "./MainLogo.module.css";
+
+export default function MainLogo() {
+  return (
+    <div className={styles.logo}>
+      <img src={MainLogoImg} alt="오픈마인드 로고이미지" />
+    </div>
+  );
+}

--- a/src/pages/main/components/MainLogo.module.css
+++ b/src/pages/main/components/MainLogo.module.css
@@ -1,0 +1,17 @@
+.logo {
+  width: 45.6rem;
+  height: 18rem;
+  margin: 16rem auto;
+
+  @media (max-width: 787px) {
+    width: 24.8rem;
+    height: 9.8rem;
+    margin: 8rem auto 2.4rem;
+  }
+}
+
+.logo img {
+  display: block;
+  width: 100%;
+  height: auto;
+}

--- a/src/pages/main/components/Sample.jsx
+++ b/src/pages/main/components/Sample.jsx
@@ -1,5 +1,0 @@
-import styles from "./Sample.module.css";
-
-export default function Sample() {
-  return <div className={styles.title}>Sample</div>;
-}

--- a/src/pages/main/components/Sample.module.css
+++ b/src/pages/main/components/Sample.module.css
@@ -1,3 +1,0 @@
-.title {
-  font-size: var(--font-size-h1);
-}


### PR DESCRIPTION
## #️⃣ 이슈

- close #77 

## 📝 작업 내용
 - MainLogo 컴포넌트에 로고이미지를 중앙에 위치하게 구현
 - 뷰크기에 따라 로고이미지 크기 변경

## 📸 결과물

https://github.com/user-attachments/assets/6b4572e9-366e-4970-a498-0196f172d95a


## 👩‍💻 공유 포인트 및 논의 사항
 - 수정할 사항 알려주시면 다시 수정하겠습니다!
