### PR TITLE
Feat(#): PostList 페이지 질문자목록 조회 api 연결

### DIFF
--- a/src/pages/post/components/PostList.jsx
+++ b/src/pages/post/components/PostList.jsx
@@ -1,5 +1,36 @@
 import styles from "./PostList.module.css";
+import React, { useState, useEffect } from "react";
+import { fetchSubjects } from "@service/Subject";
 
 export default function PostList() {
-  return <div className={styles.container}>PostList: 유섭님 작업페이지</div>;
+  const [subjects, setSubjects] = useState([]); // 질문자 목록 상태
+
+  // 질문자 목록 가져오기 함수
+  useEffect(() => {
+    async function loadSubjects() {
+      try {
+        const data = await fetchSubjects(); // 기본값: page = 1, itemsPerPage = 8, sort = "time"
+        setSubjects(data.results); // 받아온 데이터 설정
+        console.log("불러온 데이터:", data.results); // 확인용 로그
+      } catch (err) {
+        console.error("질문자 목록을 불러오는 데 실패했습니다.", err); // 에러 로그
+      }
+    }
+
+    loadSubjects();
+  }, []);
+
+  // 데이터 출력
+  return (
+    <div className={styles.container}>
+      {subjects.map((subject) => (
+        <div key={subject.id}>
+          <p>name: {subject.name}</p>
+          <p>imageSource: {subject.imageSource}</p>
+          <p>questionCount: {subject.questionCount}</p>
+          <br />
+        </div>
+      ))}
+    </div>
+  );
 }

--- a/src/pages/post/components/PostList.module.css
+++ b/src/pages/post/components/PostList.module.css
@@ -1,6 +1,7 @@
 .container {
   border: 10px solid green;
-  height: 100px;
   padding: 20px;
   margin: 20px;
+  display: flex;
+  flex-wrap: wrap;
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #82 

## 📝 작업 내용
-질문자 목록 리스트를 위한 api 호출 및 데이터 받기 테스트

## 📸 결과물
![image](https://github.com/user-attachments/assets/135b6ad2-ef7a-446a-b6cc-92bf09c69338)


## 👩‍💻 공유 포인트 및 논의 사항
페이지 작업을 세분화 해서 이슈를 만들었는데 단순 함수 호출만 이렇게 만들어도 되는지 의문이 드네요
질문자 목록 조회만 해도 UserCard, Pagination, Select 컴포넌트 연결이 가능할 것 같아서 혹시 이상한곳이 있으면 수정 바로 하겠습니다!
