### PR TITLE
Feat(#84, #93, #94, #95, #96): 피드 상세페이지 작업 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dayjs": "^1.11.13",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-intersection-observer": "^9.13.1",
         "react-lottie": "^1.2.10",
         "react-router-dom": "^7.0.2",
         "react-toastify": "^10.0.6"
@@ -3944,6 +3945,21 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.13.1.tgz",
+      "integrity": "sha512-tSzDaTy0qwNPLJHg8XZhlyHTgGW6drFKTtvjdL+p6um12rcnp8Z5XstE+QNBJ7c64n5o0Lj4ilUleA41bmDoMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dayjs": "^1.11.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-intersection-observer": "^9.13.1",
     "react-lottie": "^1.2.10",
     "react-router-dom": "^7.0.2",
     "react-toastify": "^10.0.6"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { RouterProvider } from "react-router-dom";
 import { router } from "./router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Toast } from "@components/Toast";
 
 const queryClient = new QueryClient();
 
@@ -8,6 +9,7 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
+      <Toast />
     </QueryClientProvider>
   );
 }

--- a/src/assets/img/common/icon_empty.svg
+++ b/src/assets/img/common/icon_empty.svg
@@ -1,0 +1,7 @@
+<svg width="150" height="154" viewBox="0 0 150 154" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M127.841 85.0479H96.1365L85.5683 100.317H64.4319L53.8637 85.0479H22.1592" stroke="#E4D5C9" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M40.3893 49.9788L22.1592 85.0479V115.587C22.1592 118.287 23.2726 120.876 25.2545 122.785C27.2364 124.694 29.9245 125.767 32.7274 125.767H117.273C120.076 125.767 122.764 124.694 124.746 122.785C126.728 120.876 127.841 118.287 127.841 115.587V85.0479L109.611 49.9788C108.736 48.2828 107.387 46.8556 105.716 45.8575C104.045 44.8594 102.118 44.3301 100.152 44.3291H49.8478C47.8817 44.3301 45.9548 44.8594 44.2839 45.8575C42.613 46.8556 41.2642 48.2828 40.3893 49.9788V49.9788Z" stroke="#E4D5C9" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M75.0005 21.3889L75.0005 29.9915" stroke="#E4D5C9" stroke-width="4" stroke-linecap="round"/>
+<path d="M93.7556 26.7665L87.4405 32.8494" stroke="#E4D5C9" stroke-width="4" stroke-linecap="round"/>
+<path d="M56.2454 26.7665L62.5604 32.8494" stroke="#E4D5C9" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/src/components/FeedCard/Answer.jsx
+++ b/src/components/FeedCard/Answer.jsx
@@ -3,7 +3,7 @@ import { Avatar } from "@components/Avatar";
 import { fromNow } from "@util/format";
 import styles from "./Answer.module.css";
 
-export function Answer({ answer, user, mode, isEdit, onCreate, onUpdate, onCancel }) {
+export function Answer({ answer, user, mode, isEdit, onCreate, onUpdate, onCancel, isPending }) {
   const { createdAt, isRejected, content } = answer || {};
   const { name, imageSource } = user;
   const isEditMode = mode === "answer" && isEdit;
@@ -12,12 +12,16 @@ export function Answer({ answer, user, mode, isEdit, onCreate, onUpdate, onCance
     return null;
   }
 
-  let answerContent;
-  if (isEditMode) {
-    answerContent = <AnswerForm initialValue={content} onSubmit={onUpdate} onCancel={onCancel} />;
-  } else {
-    answerContent = content ? content : <AnswerForm onSubmit={onCreate} />;
-  }
+  const answerContent = isEditMode ? (
+    <AnswerForm
+      initialValue={content}
+      onSubmit={onUpdate}
+      onCancel={onCancel}
+      isPending={isPending}
+    />
+  ) : (
+    content || <AnswerForm onSubmit={onCreate} onCancel={onCancel} isPending={isPending} />
+  );
 
   return (
     <div className={styles.answer}>
@@ -30,7 +34,11 @@ export function Answer({ answer, user, mode, isEdit, onCreate, onUpdate, onCance
           {createdAt && <span className={styles.date}>{fromNow(createdAt)}</span>}
         </div>
         <div className={styles.content}>
-          {isRejected ? <div className={styles.reject}>답변 거절</div> : answerContent}
+          {isRejected && !isEditMode ? (
+            <div className={styles.reject}>답변 거절</div>
+          ) : (
+            answerContent
+          )}
         </div>
       </div>
     </div>

--- a/src/components/FeedCard/AnswerForm.jsx
+++ b/src/components/FeedCard/AnswerForm.jsx
@@ -2,12 +2,13 @@ import { useState } from "react";
 import { InputTextarea } from "@components/Input";
 import styles from "./AnswerForm.module.css";
 
-export function AnswerForm({ initialValue = "", onSubmit, onCancel }) {
+export function AnswerForm({ initialValue = "", onSubmit, onCancel, isPending }) {
   const [value, setValue] = useState(initialValue);
 
   async function handleSubmit(e) {
     e.preventDefault();
     onSubmit(value);
+    onCancel();
   }
 
   function handleReset() {
@@ -22,7 +23,7 @@ export function AnswerForm({ initialValue = "", onSubmit, onCancel }) {
         onChange={(e) => setValue(e.target.value)}
         placeholder="답변을 입력해주세요"
       />
-      <button type="submit" className={styles.button} disabled={!value}>
+      <button type="submit" className={styles.button} disabled={!value || isPending}>
         {initialValue ? "수정" : "작성"}
       </button>
       <button type="button" onClick={handleReset} className={styles.reset}>

--- a/src/components/FeedCard/FeedCard.jsx
+++ b/src/components/FeedCard/FeedCard.jsx
@@ -3,6 +3,7 @@ import { MoreMenu, Reaction } from "@components/ui";
 import { Question, Answer, Reactions, FeedCardWrapper } from "@components/FeedCard";
 
 export function FeedCard({
+  isPending,
   question,
   mode,
   feedOwner,
@@ -13,8 +14,13 @@ export function FeedCard({
   onLike,
   onDislike,
 }) {
-  const { content, like, dislike, createAt, answer } = question;
+  const { content, like, dislike, createdAt, answer } = question;
   const [isEdit, setIsEdit] = useState(false);
+
+  function handleReject() {
+    setIsEdit(false);
+    onReject();
+  }
 
   function handleModify() {
     setIsEdit(true);
@@ -26,10 +32,10 @@ export function FeedCard({
 
   return (
     <FeedCardWrapper>
-      <Question status={!!answer} createAt={createAt} content={content}>
+      <Question status={!!answer} createdAt={createdAt} content={content}>
         {mode === "answer" && (
           <MoreMenu>
-            <MoreMenu.Item icon="reject" onClick={onReject}>
+            <MoreMenu.Item icon="reject" onClick={handleReject}>
               거절하기
             </MoreMenu.Item>
             <MoreMenu.Item icon="edit" onClick={handleModify}>
@@ -42,6 +48,7 @@ export function FeedCard({
         )}
       </Question>
       <Answer
+        isPending={isPending}
         answer={answer}
         user={feedOwner}
         mode={mode}

--- a/src/components/FeedCard/FeedCardWrapper.module.css
+++ b/src/components/FeedCard/FeedCardWrapper.module.css
@@ -2,4 +2,5 @@
   padding: 3.2rem;
   border-radius: var(--border-radius-lg);
   box-shadow: var(--shadow-100);
+  background: var(--color-white);
 }

--- a/src/components/FeedCard/Question.jsx
+++ b/src/components/FeedCard/Question.jsx
@@ -2,7 +2,7 @@ import { Badge } from "@components/ui";
 import { fromNow } from "@util/format";
 import styles from "./Question.module.css";
 
-export function Question({ status, createAt, content, children }) {
+export function Question({ status, createdAt, content, children }) {
   return (
     <>
       <header className={styles.header}>
@@ -10,7 +10,7 @@ export function Question({ status, createAt, content, children }) {
         {children}
       </header>
       <div className={styles.question}>
-        <div className={styles.meta}>질문 · {fromNow(createAt)}</div>
+        <div className={styles.meta}>질문 · {fromNow(createdAt)}</div>
         <h3 className={styles.title}>{content}</h3>
       </div>
     </>

--- a/src/pages/post/PostAnswerPage.jsx
+++ b/src/pages/post/PostAnswerPage.jsx
@@ -1,13 +1,24 @@
 import { useParams } from "react-router-dom";
+import useQuestions from "./components/useQuestions";
+import PostMessage from "./components/PostMessage";
 import Questions from "./components/Questions";
 
 export default function PostAnswerPage() {
   const { id } = useParams();
+  const { count, results, ref, error, isLoading, isFetchingNextPage } = useQuestions(id);
+
+  if (error) {
+    return <PostMessage>질문을 가져오는중에 문제가 생겼습니다.</PostMessage>;
+  }
+
+  if (isLoading) {
+    return <PostMessage>질문을 가져오는 중입니다.</PostMessage>;
+  }
 
   return (
-    <div>
-      답변페이지
-      <Questions />
-    </div>
+    <>
+      <Questions count={count} data={results} mode="answer" />
+      <div ref={ref}>{isFetchingNextPage ? "더 불러오는 중입니다..." : ""}</div>
+    </>
   );
 }

--- a/src/pages/post/PostDetailPage.jsx
+++ b/src/pages/post/PostDetailPage.jsx
@@ -1,13 +1,26 @@
 import { useParams } from "react-router-dom";
+import useQuestions from "./components/useQuestions";
+import PostMessage from "./components/PostMessage";
 import Questions from "./components/Questions";
+import QuestionForm from "./components/QuestionForm";
 
 export default function PostDetailPage() {
   const { id } = useParams();
+  const { count, results, ref, error, isLoading, isFetchingNextPage } = useQuestions(id);
+
+  if (error) {
+    return <PostMessage>질문을 가져오는중에 문제가 생겼습니다.</PostMessage>;
+  }
+
+  if (isLoading) {
+    return <PostMessage>질문을 가져오는 중입니다.</PostMessage>;
+  }
 
   return (
-    <div>
-      질문 페이지
-      <Questions />
-    </div>
+    <>
+      <QuestionForm />
+      <Questions count={count} data={results} />
+      <div ref={ref}>{isFetchingNextPage ? "더 불러오는 중입니다..." : ""}</div>
+    </>
   );
 }

--- a/src/pages/post/components/PostMessage.jsx
+++ b/src/pages/post/components/PostMessage.jsx
@@ -1,0 +1,5 @@
+import styles from "./PostMessage.module.css";
+
+export default function PostMessage({ children }) {
+  return <div className={styles.message}>{children}</div>;
+}

--- a/src/pages/post/components/PostMessage.module.css
+++ b/src/pages/post/components/PostMessage.module.css
@@ -1,0 +1,8 @@
+.message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2em 0;
+  text-align: center;
+  color: var(--color-primary-400);
+}

--- a/src/pages/post/components/QuestionForm.jsx
+++ b/src/pages/post/components/QuestionForm.jsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { useParams, useRouteLoaderData } from "react-router-dom";
+import useQuestion from "./useQuestion";
+import { Modal, InputTextarea, Avatar } from "@components/ui";
+import usePreventScroll from "@components/Modal/usePreventScroll";
+import styles from "./QuestionForm.module.css";
+
+export default function QuestionForm() {
+  const { id } = useParams();
+  const { name, imageSource } = useRouteLoaderData("post");
+  const [question, setQuestion] = useState("");
+  const [isModal, setIsModal] = useState(false);
+  const { mutate, isPending } = useQuestion(id);
+  const { preventScroll, allowScroll } = usePreventScroll();
+
+  const handleToggleModal = () => {
+    setQuestion("");
+    setIsModal(!isModal);
+    isModal ? allowScroll() : preventScroll();
+  };
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    mutate({
+      id,
+      question,
+    });
+    handleToggleModal();
+  }
+
+  return (
+    <>
+      <button type="button" onClick={handleToggleModal} className={styles.floatButton}>
+        질문 작성<em>하기</em>
+      </button>
+      {isModal && (
+        <Modal handleToggleModal={handleToggleModal} title="질문을 작성하세요" icon="message">
+          <div className={styles.user}>
+            <span className={styles.to}>To.</span>
+            <Avatar src={imageSource} alt={name} size={28} />
+            <span className={styles.name}>{name}</span>
+          </div>
+          <form onSubmit={handleSubmit}>
+            <InputTextarea
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              placeholder="질문을 입력해주세요"
+            />
+            <button type="submit" disabled={!question || isPending} className={styles.button}>
+              질문 보내기
+            </button>
+          </form>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/pages/post/components/QuestionForm.module.css
+++ b/src/pages/post/components/QuestionForm.module.css
@@ -1,0 +1,46 @@
+.user {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-12);
+}
+
+.floatButton {
+  z-index: 100;
+  position: fixed;
+  right: var(--spacing-24);
+  bottom: var(--spacing-24);
+  display: flex;
+  align-items: center;
+  padding: 0 5rem;
+  height: 5.4rem;
+  border-radius: var(--board-radius-xl);
+  background: var(--color-primary-400);
+  color: var(--color-white);
+}
+
+@media (width < 768px) {
+  .floatButton {
+    padding: 0 2.4rem;
+  }
+
+  .floatButton em {
+    display: none;
+  }
+}
+
+.button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 4.6rem;
+  margin-top: var(--spacing-8);
+  border-radius: var(--border-radius-md);
+  background: var(--color-primary-400);
+  color: var(--color-white);
+}
+
+.button:disabled {
+  background: var(--color-primary-300);
+}

--- a/src/pages/post/components/Questions.jsx
+++ b/src/pages/post/components/Questions.jsx
@@ -1,5 +1,66 @@
+import { useRouteLoaderData } from "react-router-dom";
+import { Icon } from "@components/ui";
+import { FeedCard } from "@components/FeedCard";
+import emptyIcon from "@assets/img/common/icon_empty.svg";
 import styles from "./Questions.module.css";
+import useLike from "./useLike";
+import useAnswer from "./useAnswer";
 
-export default function Questions() {
-  return <div className={styles.container}>Questions & anwers : 찬기 작업페이지</div>;
+export default function Questions({ count, data, mode = "view" }) {
+  const userInfo = useRouteLoaderData("post");
+  const { create, update, remove, reject, isPending } = useAnswer();
+  const { mutate: handleLike } = useLike();
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <Icon name="message" />
+        {count > 0 ? `${count}개의 질문이 있습니다.` : "아직 질문이 없습니다"}
+      </header>
+
+      {data.length ? (
+        <ul className={styles.list}>
+          {data.map((question) => {
+            return (
+              <li key={question.id}>
+                <FeedCard
+                  isPending={isPending}
+                  question={question}
+                  mode={mode}
+                  feedOwner={userInfo}
+                  onCreate={(content) =>
+                    create({ questionId: question.id, content, isRejected: "false" })
+                  }
+                  onUpdate={(content) =>
+                    update({
+                      answerId: question.answer?.id,
+                      content,
+                      isRejected: "false",
+                    })
+                  }
+                  onDelete={() =>
+                    remove({ questionId: question.id, answerId: question.answer?.id })
+                  }
+                  onReject={() =>
+                    reject({
+                      questionId: question.id,
+                      answerId: question.answer?.id,
+                      content: "reject",
+                      isRejected: true,
+                    })
+                  }
+                  onLike={() => handleLike({ id: question.id, type: "like" })}
+                  onDislike={() => handleLike({ id: question.id, type: "dislike" })}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <div className={styles.empty}>
+          <img src={emptyIcon} alt="아직 질문이 없습니다." />
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/pages/post/components/Questions.module.css
+++ b/src/pages/post/components/Questions.module.css
@@ -1,6 +1,18 @@
 .container {
-  border: 10px solid green;
-  height: 100px;
-  padding: 20px;
-  margin: 20px;
+  padding: var(--spacing-16);
+  background: var(--color-primary-100);
+  border-radius: var(--border-radius-lg);
+  border: 1px solid var(--color-primary-300);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  margin-bottom: var(--spacing-16);
+}
+
+.list > li + li {
+  margin-top: var(--spacing-20);
 }

--- a/src/pages/post/components/useAnswer.js
+++ b/src/pages/post/components/useAnswer.js
@@ -1,0 +1,123 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Notify } from "@components/Toast";
+import { createAnswer, deleteAnswer, updateAnswer } from "@service/Answer";
+
+export default function useAnswer() {
+  const queryClient = useQueryClient();
+
+  const create = useMutation({
+    mutationFn: ({ questionId, content, isRejected }) => {
+      return createAnswer(questionId, content, isRejected);
+    },
+    onError: () => Notify({ type: "error", message: "문제가 생겨서, 답변 생성을 실패했습니다." }),
+    onSuccess: async (data) => {
+      queryClient.setQueryData(["questions"], (prev) => {
+        if (!prev) return prev;
+
+        const newData = {
+          ...prev,
+          pages: prev.pages.map((page) => ({
+            ...page,
+            results: page.results.map((item) =>
+              item.id === data.questionId ? { ...item, answer: data } : item,
+            ),
+          })),
+        };
+
+        return newData;
+      });
+    },
+  });
+
+  const update = useMutation({
+    mutationFn: ({ answerId, content, isRejected }) => {
+      return updateAnswer(answerId, content, isRejected);
+    },
+    onError: () => Notify({ type: "error", message: "문제가 생겨서, 답변 수정을 실패했습니다." }),
+    onSuccess: async (data) => {
+      queryClient.setQueryData(["questions"], (prev) => {
+        if (!prev) return prev;
+
+        const newData = {
+          ...prev,
+          pages: prev.pages.map((page) => ({
+            ...page,
+            results: page.results.map((item) =>
+              item.id === data.questionId ? { ...item, answer: data } : item,
+            ),
+          })),
+        };
+
+        return newData;
+      });
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: ({ answerId }) => {
+      if (!answerId) return Notify({ type: "error", message: "삭제할 내용이 없습니다." });
+      return deleteAnswer(answerId);
+    },
+    onError: () => Notify({ type: "error", message: "문제가 생겨서, 답변 삭제를 실패했습니다." }),
+    onSuccess: (_, { questionId }) => {
+      queryClient.setQueryData(["questions"], (prev) => {
+        if (!prev) return prev;
+
+        const newData = {
+          ...prev,
+          pages: prev.pages.map((page) => ({
+            ...page,
+            results: page.results.map((item) => {
+              if (item.id === questionId) {
+                const newItem = { ...item };
+                delete newItem.answer;
+                return newItem;
+              }
+              return item;
+            }),
+          })),
+        };
+
+        return newData;
+      });
+    },
+  });
+
+  const reject = useMutation({
+    mutationFn: ({ questionId, answerId, content, isRejected }) => {
+      if (answerId) {
+        return updateAnswer(answerId, content, isRejected);
+      } else {
+        return createAnswer(questionId, content, isRejected);
+      }
+    },
+    onError: () => Notify({ type: "error", message: "문제가 생겨서, 거절을 실패했습니다." }),
+    onSuccess: async (data) => {
+      queryClient.setQueryData(["questions"], (prev) => {
+        if (!prev) return prev;
+
+        const newData = {
+          ...prev,
+          pages: prev.pages.map((page) => ({
+            ...page,
+            results: page.results.map((item) =>
+              item.id === data.questionId ? { ...item, answer: data } : item,
+            ),
+          })),
+        };
+
+        return newData;
+      });
+    },
+  });
+
+  const isPending = create.isPending || update.isPending || remove.isPending || reject.isPending;
+
+  return {
+    create: create.mutate,
+    update: update.mutate,
+    remove: remove.mutate,
+    reject: reject.mutate,
+    isPending,
+  };
+}

--- a/src/pages/post/components/useLike.js
+++ b/src/pages/post/components/useLike.js
@@ -1,0 +1,54 @@
+import { addQuestionReaction } from "@service/Question";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export default function useLike() {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationFn: ({ id, type }) => addQuestionReaction(id, type),
+    onMutate: async ({ id, type }) => {
+      // 에러시 원복 데이터 생성
+      const prevData = queryClient.getQueriesData(["questions"]);
+
+      // optimistic update (기존 데이터 이용해서 ui바로 업데이트)
+      queryClient.setQueryData(["questions"], (prev) => {
+        if (!prev) return prev;
+
+        const newData = {
+          ...prev,
+          pages: prev.pages.map((page) => ({
+            ...page,
+            results: page.results.map((item) =>
+              item.id === id ? { ...item, [type]: item[type] + 1 } : item,
+            ),
+          })),
+        };
+        return newData;
+      });
+
+      return { prevData };
+    },
+    onError: (error, _, context) => {
+      // 에러시 다시 원복
+      queryClient.setQueryData(["questions"], context.prevData);
+    },
+    onSuccess: async (data) => {
+      // 성공하면서 받아온 데이터로 바꿔치기
+      queryClient.setQueryData(["questions"], (prev) => {
+        if (!prev) return prev;
+
+        const newData = {
+          ...prev,
+          pages: prev.pages.map((page) => ({
+            ...page,
+            results: page.results.map((item) => (item.id === data.id ? data : item)),
+          })),
+        };
+
+        return newData;
+      });
+    },
+  });
+
+  return { mutate };
+}

--- a/src/pages/post/components/useQuestions.js
+++ b/src/pages/post/components/useQuestions.js
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInView } from "react-intersection-observer";
+import { fetchQuestions } from "@service/Question";
+
+export default function useQuestions(id) {
+  const { data, error, fetchNextPage, isFetchingNextPage, hasNextPage, isLoading } =
+    useInfiniteQuery({
+      queryKey: ["questions"],
+      queryFn: ({ pageParam }) => fetchQuestions(id, pageParam, 5),
+      initialPageParam: 1,
+      getNextPageParam: (lastPage, pages) => {
+        return lastPage.next ? pages.length + 1 : null;
+      },
+    });
+
+  const { ref, inView } = useInView();
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, inView, hasNextPage]);
+
+  const count = data?.pages[0].count;
+  const results = data?.pages.flatMap((page) => page.results);
+
+  return { count, results, ref, error, isLoading, isFetchingNextPage };
+}


### PR DESCRIPTION
## #️⃣ 이슈

- close #84 
- close #93 
- close #94 
- close #95 
- close #96 

## 📝 작업 내용
상세페이지 작업을 1차적으로 했습니다.
- 질문 리스트 조회 (무한스크롤)
- 질문 작성
- 질문 및 답변 리스트 조회 (무한스크롤)
- 답변 작성/수정/거절/삭제

프리뷰url에서 아래 주소를 확인하시면 결과를 보실수있어요
- https://deploy-preview-97--openmind-sprint12.netlify.app/post/9281
- https://deploy-preview-97--openmind-sprint12.netlify.app/post/9281/answer

## 📸 결과물
![image](https://github.com/user-attachments/assets/d0fcdb28-8007-41e8-9772-e608b20d17ce)

## 👩‍💻 공유 포인트 및 논의 사항
- 이어서 반응형 css와 추가적인 개선사항도 더 작업 예정입니다.
- 버튼 공용컴포넌트 완성되면 교체도 해야되구욤
- 리액트쿼리 너무 좋은것 같네요...
- 공식문서가 너무 잘되어있어서 별로 어렵지않게 사용했습니다.
- 한솔님이 만들어주신 모달, 토스트 팝업덕분에 빨리 끝났습니다.