### PR TITLE
Feat(#109): PostList 페이지 Dropdown 컴포넌트 연결 sort기능 구현

### DIFF
--- a/src/pages/post/components/PostList.jsx
+++ b/src/pages/post/components/PostList.jsx
@@ -1,13 +1,14 @@
 import styles from "./PostList.module.css";
 import React, { useState, useEffect } from "react";
 import { fetchSubjects } from "@service/Subject";
-import { UserCard, Pagination } from "@components/ui"; //Pagination 추가
+import { UserCard, Pagination, Select } from "@components/ui"; //Pagination 추가
 
 export default function PostList() {
   const [subjects, setSubjects] = useState([]); // 질문자 목록 상태
   const [totalItems, setTotalItems] = useState(0); // 전체 항목 수
   const [currentPage, setCurrentPage] = useState(1); // 현재 페이지 상태
   const [itemsPerPage, setItemsPerPage] = useState(8); // 한 페이지에 보여줄 데이터 수 (기본값)
+  const [sort, setSort] = useState("name"); // 정렬 기준 상태 (기본값: 이름순)
 
   // 화면 크기에 따라 itemsPerPage 조정
   useEffect(() => {
@@ -37,8 +38,7 @@ export default function PostList() {
   useEffect(() => {
     async function loadSubjects() {
       try {
-        // 현재 페이지와 항목 수, 이름순 정렬 기준으로 질문자 목록 데이터를 가져옵니다.
-        const data = await fetchSubjects(currentPage, itemsPerPage, "name");
+        const data = await fetchSubjects(currentPage, itemsPerPage, sort);
         setSubjects(data.results); // 받아온 데이터 설정
         setTotalItems(data.count); // 총 데이터 수 설정
       } catch (err) {
@@ -47,16 +47,29 @@ export default function PostList() {
     }
 
     loadSubjects();
-  }, [currentPage, itemsPerPage]); // currentPage와 itemsPerPage가 변경될 때 실행
+  }, [currentPage, itemsPerPage, sort]); // currentPage, itemsPerPage, sort 변경 시 실행
 
   // 페이지 변경 함수
   function handlePageChange(page) {
     setCurrentPage(page); // 현재 페이지 변경
   }
 
+  // 정렬 기준 변경 함수
+  function handleSortChange(value) {
+    setSort(value); // 정렬 기준 업데이트
+    setCurrentPage(1); // 정렬 기준 변경 시 첫 페이지로 이동
+  }
+
   // 데이터 출력
   return (
     <div className={styles.container}>
+      <div className={styles.sortBar}>
+        <Select value={sort} onChange={handleSortChange}>
+          <Select.Option value="name">이름순</Select.Option>
+          <Select.Option value="time">최신순</Select.Option>
+        </Select>
+      </div>
+
       <div className={styles.userCardGrid}>
         {subjects.map((subject) => (
           <UserCard

--- a/src/pages/post/components/PostList.jsx
+++ b/src/pages/post/components/PostList.jsx
@@ -1,38 +1,30 @@
 import styles from "./PostList.module.css";
 import React, { useState, useEffect } from "react";
 import { fetchSubjects } from "@service/Subject";
-import { UserCard, Pagination, Select } from "@components/ui"; //Pagination 추가
+import { UserCard, Pagination, Select } from "@components/ui";
+import { getItemsPerPage } from "./itemPerPage";
 
 export default function PostList() {
   const [subjects, setSubjects] = useState([]); // 질문자 목록 상태
   const [totalItems, setTotalItems] = useState(0); // 전체 항목 수
   const [currentPage, setCurrentPage] = useState(1); // 현재 페이지 상태
-  const [itemsPerPage, setItemsPerPage] = useState(8); // 한 페이지에 보여줄 데이터 수 (기본값)
+  const [itemsPerPage, setItemsPerPage] = useState(getItemsPerPage()); // 화면 크기에 맞춰 itemsPerPage값 가져오기
   const [sort, setSort] = useState("name"); // 정렬 기준 상태 (기본값: 이름순)
 
-  // 화면 크기에 따라 itemsPerPage 조정
+  // 화면 크기 변화 감지 및 itemsPerPage 업데이트
   useEffect(() => {
     function handleResize() {
-      const screenWidth = window.innerWidth;
-
-      if (screenWidth <= 768) {
-        setItemsPerPage(6); // 모바일: 한 페이지에 6개
-      } else if (screenWidth <= 1200) {
-        setItemsPerPage(6); // 태블릿: 한 페이지에 6개
-      } else {
-        setItemsPerPage(8); // PC: 한 페이지에 8개
-      }
+      setItemsPerPage(getItemsPerPage()); // 화면 크기에 맞는 itemsPerPage 값을 업데이트
     }
 
-    // 초기 실행 및 이벤트 등록
-    handleResize();
+    // 브라우저의 크기 조정 이벤트 리스너 추가
     window.addEventListener("resize", handleResize);
 
-    // 이벤트 클린업
+    // 이벤트 리스너 제거
     return () => {
       window.removeEventListener("resize", handleResize);
     };
-  }, []); // 빈 배열로 실행 조건 설정 (최초 렌더링 시 실행)
+  }, []); // 빈 배열로 의존성 설정 (최초 렌더링 시에만 실행)
 
   // 질문자 목록 가져오기 함수
   useEffect(() => {

--- a/src/pages/post/components/PostList.jsx
+++ b/src/pages/post/components/PostList.jsx
@@ -8,7 +8,7 @@ export default function PostList() {
   const [subjects, setSubjects] = useState([]); // 질문자 목록 상태
   const [totalItems, setTotalItems] = useState(0); // 전체 항목 수
   const [currentPage, setCurrentPage] = useState(1); // 현재 페이지 상태
-  const [itemsPerPage, setItemsPerPage] = useState(getItemsPerPage()); // 화면 크기에 맞춰 itemsPerPage값 가져오기
+  const [itemsPerPage, setItemsPerPage] = useState(() => getItemsPerPage()); //게으른 초기화 방식
   const [sort, setSort] = useState("name"); // 정렬 기준 상태 (기본값: 이름순)
 
   // 화면 크기 변화 감지 및 itemsPerPage 업데이트

--- a/src/pages/post/components/PostList.module.css
+++ b/src/pages/post/components/PostList.module.css
@@ -7,6 +7,15 @@
   gap: var(--spacing-20); /* 컴포넌트 간 간격 */
 }
 
+.sortBar {
+  display: flex;
+  justify-content: center;
+}
+
+.sortBar select {
+  max-width: 80px; /* DropDown 너비 */
+}
+
 .userCardGrid {
   display: grid;
   grid-template-columns: repeat(4, minmax(18.6rem, 1fr)); /* 카드의 최소 너비와 일치 */

--- a/src/pages/post/components/itemPerPage.js
+++ b/src/pages/post/components/itemPerPage.js
@@ -1,0 +1,11 @@
+export function getItemsPerPage() {
+  const screenWidth = window.innerWidth;
+
+  if (screenWidth <= 768) {
+    return 6; // 모바일: 한 페이지에 6개
+  } else if (screenWidth <= 1200) {
+    return 6; // 태블릿: 한 페이지에 6개
+  } else {
+    return 8; // PC: 한 페이지에 8개
+  }
+}


### PR DESCRIPTION
## #️⃣ 이슈

- close #109 

## 📝 작업 내용
-Select 컴포넌트를 사용하여 PostList페이지 최신순/이름순 정렬기능 구현 및 css 스타일링
-페이지 새로고침 시 화면사이즈에 맞게 usercard 갯수가 설정되지 않아서 화면사이즈 확인 후 itemperpage
를 세팅해주는 함수를 외부에서 가져오게 따로 만들었습니다.
## 📸 결과물
![image](https://github.com/user-attachments/assets/536b6def-f235-4f2b-ad07-1b85153b2ce9)
![image](https://github.com/user-attachments/assets/29af9900-d9a9-41ea-a987-1216fff3a6ee)
![image](https://github.com/user-attachments/assets/93358c7e-c9d9-4909-aa1f-bc6a9be91ff0)

- 잘못된 질문자 목록
![잘못된 질문자리스트](https://github.com/user-attachments/assets/4a7308c4-6c27-48a7-ba49-02cb71de66c7)

- 수정 후
![image](https://github.com/user-attachments/assets/e9877158-5d18-4b7d-9704-dd5862ea0257)


## 👩‍💻 공유 포인트 및 논의 사항
페이지에서 화면 사이즈 확인 후 가져올 질문자 목록 수를 정하는것보다 외부에서 만들어
페이지 함수 시작전에 체크하는게 맞는지 모르겠습니다. 일단 동작은 하는것같아요