### PR TITLE
Refactor(#129): 질문, 답변 페이지 리팩토링 (훅 재정비)

### DIFF
--- a/src/components/FeedCard/Answer.jsx
+++ b/src/components/FeedCard/Answer.jsx
@@ -2,21 +2,27 @@ import { AnswerForm } from "@components/FeedCard";
 import { Avatar } from "@components/Avatar";
 import { fromNow } from "@util/format";
 import styles from "./Answer.module.css";
+import { forwardRef, useImperativeHandle, useState } from "react";
 
-export function Answer({
-  questionId,
-  answer,
-  user,
-  mode,
-  isEdit,
-  onCreate,
-  onUpdate,
-  onCancel,
-  isPending,
-}) {
+export const Answer = forwardRef(function Answer(
+  { questionId, answer, user, mode, onCreate, onUpdate, isPending },
+  ref,
+) {
+  const [isEdit, setIsEdit] = useState(false);
   const { id: answerId, createdAt, isRejected, content } = answer || {};
   const { name, imageSource } = user;
   const isEditMode = mode === "answer" && isEdit;
+
+  useImperativeHandle(ref, () => {
+    return {
+      openEdit: () => setIsEdit(true),
+      closeEdit: () => setIsEdit(false),
+    };
+  });
+
+  function handleCancel() {
+    setIsEdit(false);
+  }
 
   if (!answer && mode === "view") {
     return null;
@@ -34,7 +40,7 @@ export function Answer({
           questionId={questionId}
           answerId={answerId}
           onSubmit={onUpdate}
-          onCancel={onCancel}
+          onCancel={handleCancel}
           isPending={isPending}
         />
       );
@@ -46,7 +52,7 @@ export function Answer({
           questionId={questionId}
           answerId={answerId}
           onSubmit={onCreate}
-          onCancel={onCancel}
+          onCancel={handleCancel}
           isPending={isPending}
         />
       )
@@ -67,4 +73,4 @@ export function Answer({
       </div>
     </div>
   );
-}
+});

--- a/src/components/FeedCard/Answer.jsx
+++ b/src/components/FeedCard/Answer.jsx
@@ -22,26 +22,36 @@ export function Answer({
     return null;
   }
 
-  const answerContent = isEditMode ? (
-    <AnswerForm
-      questionId={questionId}
-      answerId={answerId}
-      initialValue={content}
-      onSubmit={onUpdate}
-      onCancel={onCancel}
-      isPending={isPending}
-    />
-  ) : (
-    content || (
-      <AnswerForm
-        questionId={questionId}
-        answerId={answerId}
-        onSubmit={onCreate}
-        onCancel={onCancel}
-        isPending={isPending}
-      />
-    )
-  );
+  function renderAnswerContent() {
+    if (isRejected && !isEditMode) {
+      return <div className={styles.reject}>답변 거절</div>;
+    }
+
+    if (isEditMode) {
+      return (
+        <AnswerForm
+          initialValue={content}
+          questionId={questionId}
+          answerId={answerId}
+          onSubmit={onUpdate}
+          onCancel={onCancel}
+          isPending={isPending}
+        />
+      );
+    }
+
+    return (
+      content || (
+        <AnswerForm
+          questionId={questionId}
+          answerId={answerId}
+          onSubmit={onCreate}
+          onCancel={onCancel}
+          isPending={isPending}
+        />
+      )
+    );
+  }
 
   return (
     <div className={styles.answer}>
@@ -53,13 +63,7 @@ export function Answer({
           <span className={styles.name}>{name}</span>
           {createdAt && <span className={styles.date}>{fromNow(createdAt)}</span>}
         </div>
-        <div className={styles.content}>
-          {isRejected && !isEditMode ? (
-            <div className={styles.reject}>답변 거절</div>
-          ) : (
-            answerContent
-          )}
-        </div>
+        <div className={styles.content}>{renderAnswerContent()}</div>
       </div>
     </div>
   );

--- a/src/components/FeedCard/AnswerButton.jsx
+++ b/src/components/FeedCard/AnswerButton.jsx
@@ -1,0 +1,19 @@
+import { useFeed } from "@context/FeedContext";
+import { Link, useParams } from "react-router-dom";
+import styles from "./AnswerButton.module.css";
+
+export function AnswerButton() {
+  const { id } = useParams();
+  const { hasFeed } = useFeed();
+  const isOwner = hasFeed(id);
+
+  if (!isOwner) return null;
+
+  return (
+    <div className={styles.controls}>
+      <Link to={`/post/${id}/answer`} className={styles.button}>
+        답변하러가기
+      </Link>
+    </div>
+  );
+}

--- a/src/components/FeedCard/AnswerButton.module.css
+++ b/src/components/FeedCard/AnswerButton.module.css
@@ -1,0 +1,13 @@
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: -2em;
+}
+
+a.button {
+  padding: 1em 0;
+  margin-bottom: 1em;
+  color: var(--color-primary-400);
+  text-decoration: underline;
+}

--- a/src/components/FeedCard/AnswerMenu.jsx
+++ b/src/components/FeedCard/AnswerMenu.jsx
@@ -1,0 +1,19 @@
+import { MoreMenu } from "@components/Dropdown";
+
+export function AnswerMenu({ mode, answer, onReject, onModify, onDelete }) {
+  if (mode === "view") return null;
+
+  return (
+    <MoreMenu>
+      <MoreMenu.Item icon="reject" onClick={onReject} disabled={answer?.isRejected}>
+        거절하기
+      </MoreMenu.Item>
+      <MoreMenu.Item icon="edit" onClick={onModify}>
+        수정하기
+      </MoreMenu.Item>
+      <MoreMenu.Item icon="close" onClick={onDelete} disabled={!answer}>
+        삭제하기
+      </MoreMenu.Item>
+    </MoreMenu>
+  );
+}

--- a/src/components/FeedCard/FeedCard.jsx
+++ b/src/components/FeedCard/FeedCard.jsx
@@ -3,14 +3,14 @@ import { MoreMenu, Reaction } from "@components/ui";
 import { Question, Answer, Reactions, FeedCardWrapper } from "@components/FeedCard";
 
 export function FeedCard({
-  isPending,
-  question,
   mode,
+  question,
   feedOwner,
-  onUpdate,
-  onCreate,
-  onDelete,
-  onReject,
+  isPending,
+  onCreateAnswer,
+  onUpdateAnswer,
+  onDeleteAnswer,
+  onRejectAnswer,
   onLike,
 }) {
   const { id: questionId, content, like, dislike, createdAt, answer } = question;
@@ -18,30 +18,17 @@ export function FeedCard({
 
   function handleReject() {
     setIsEdit(false);
-    onReject({
+    onRejectAnswer({
       questionId,
-      answerId: answer && answer.id,
+      answerId: answer?.id,
     });
-  }
-
-  function handleModify() {
-    setIsEdit(true);
-  }
-
-  function handleCancel() {
-    setIsEdit(false);
   }
 
   function handleDelete() {
-    onDelete({
+    onDeleteAnswer({
       questionId,
-      answerId: answer && answer.id,
+      answerId: answer?.id,
     });
-  }
-
-  function handleLike(e) {
-    const type = e.currentTarget.dataset.like;
-    onLike({ questionId, type });
   }
 
   return (
@@ -49,13 +36,13 @@ export function FeedCard({
       <Question status={!!answer} createdAt={createdAt} content={content}>
         {mode === "answer" && (
           <MoreMenu>
-            <MoreMenu.Item icon="reject" onClick={handleReject}>
+            <MoreMenu.Item icon="reject" onClick={handleReject} disabled={answer?.isRejected}>
               거절하기
             </MoreMenu.Item>
-            <MoreMenu.Item icon="edit" onClick={handleModify}>
+            <MoreMenu.Item icon="edit" onClick={() => setIsEdit(true)}>
               수정하기
             </MoreMenu.Item>
-            <MoreMenu.Item icon="close" onClick={handleDelete}>
+            <MoreMenu.Item icon="close" onClick={handleDelete} disabled={!answer}>
               삭제하기
             </MoreMenu.Item>
           </MoreMenu>
@@ -68,13 +55,13 @@ export function FeedCard({
         user={feedOwner}
         mode={mode}
         isEdit={isEdit}
-        onCreate={onCreate}
-        onUpdate={onUpdate}
-        onCancel={handleCancel}
+        onCreate={onCreateAnswer}
+        onUpdate={onUpdateAnswer}
+        onCancel={() => setIsEdit(false)}
       />
       <Reactions>
-        <Reaction type="like" count={like} onClick={handleLike} data-like="like" />
-        <Reaction type="dislike" count={dislike} onClick={handleLike} data-like="dislike" />
+        <Reaction type="like" count={like} onClick={() => onLike(questionId, "like")} />
+        <Reaction type="dislike" count={dislike} onClick={() => onLike(questionId, "dislike")} />
       </Reactions>
     </FeedCardWrapper>
   );

--- a/src/components/FeedCard/FeedCard.jsx
+++ b/src/components/FeedCard/FeedCard.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef } from "react";
 import { MoreMenu, Reaction } from "@components/ui";
 import { Question, Answer, Reactions, FeedCardWrapper } from "@components/FeedCard";
 
@@ -14,14 +14,18 @@ export function FeedCard({
   onLike,
 }) {
   const { id: questionId, content, like, dislike, createdAt, answer } = question;
-  const [isEdit, setIsEdit] = useState(false);
+  const answerRef = useRef(null);
 
   function handleReject() {
-    setIsEdit(false);
+    answerRef.current.closeEdit();
     onRejectAnswer({
       questionId,
       answerId: answer?.id,
     });
+  }
+
+  function handleModify() {
+    answerRef.current.openEdit();
   }
 
   function handleDelete() {
@@ -39,7 +43,7 @@ export function FeedCard({
             <MoreMenu.Item icon="reject" onClick={handleReject} disabled={answer?.isRejected}>
               거절하기
             </MoreMenu.Item>
-            <MoreMenu.Item icon="edit" onClick={() => setIsEdit(true)}>
+            <MoreMenu.Item icon="edit" onClick={handleModify}>
               수정하기
             </MoreMenu.Item>
             <MoreMenu.Item icon="close" onClick={handleDelete} disabled={!answer}>
@@ -49,15 +53,14 @@ export function FeedCard({
         )}
       </Question>
       <Answer
+        ref={answerRef}
         questionId={questionId}
         isPending={isPending}
         answer={answer}
         user={feedOwner}
         mode={mode}
-        isEdit={isEdit}
         onCreate={onCreateAnswer}
         onUpdate={onUpdateAnswer}
-        onCancel={() => setIsEdit(false)}
       />
       <Reactions>
         <Reaction type="like" count={like} onClick={() => onLike({ questionId, type: "like" })} />

--- a/src/components/FeedCard/FeedCard.jsx
+++ b/src/components/FeedCard/FeedCard.jsx
@@ -60,8 +60,12 @@ export function FeedCard({
         onCancel={() => setIsEdit(false)}
       />
       <Reactions>
-        <Reaction type="like" count={like} onClick={() => onLike(questionId, "like")} />
-        <Reaction type="dislike" count={dislike} onClick={() => onLike(questionId, "dislike")} />
+        <Reaction type="like" count={like} onClick={() => onLike({ questionId, type: "like" })} />
+        <Reaction
+          type="dislike"
+          count={dislike}
+          onClick={() => onLike({ questionId, type: "dislike" })}
+        />
       </Reactions>
     </FeedCardWrapper>
   );

--- a/src/components/FeedCard/FeedCard.jsx
+++ b/src/components/FeedCard/FeedCard.jsx
@@ -1,6 +1,5 @@
 import { useRef } from "react";
-import { MoreMenu, Reaction } from "@components/ui";
-import { Question, Answer, Reactions, FeedCardWrapper } from "@components/FeedCard";
+import { Question, Answer, Reactions, FeedCardWrapper, AnswerMenu } from "@components/FeedCard";
 
 export function FeedCard({
   mode,
@@ -38,19 +37,13 @@ export function FeedCard({
   return (
     <FeedCardWrapper>
       <Question status={!!answer} createdAt={createdAt} content={content}>
-        {mode === "answer" && (
-          <MoreMenu>
-            <MoreMenu.Item icon="reject" onClick={handleReject} disabled={answer?.isRejected}>
-              거절하기
-            </MoreMenu.Item>
-            <MoreMenu.Item icon="edit" onClick={handleModify}>
-              수정하기
-            </MoreMenu.Item>
-            <MoreMenu.Item icon="close" onClick={handleDelete} disabled={!answer}>
-              삭제하기
-            </MoreMenu.Item>
-          </MoreMenu>
-        )}
+        <AnswerMenu
+          mode={mode}
+          answer={answer}
+          onReject={handleReject}
+          onModify={handleModify}
+          onDelete={handleDelete}
+        />
       </Question>
       <Answer
         ref={answerRef}
@@ -62,14 +55,7 @@ export function FeedCard({
         onCreate={onCreateAnswer}
         onUpdate={onUpdateAnswer}
       />
-      <Reactions>
-        <Reaction type="like" count={like} onClick={() => onLike({ questionId, type: "like" })} />
-        <Reaction
-          type="dislike"
-          count={dislike}
-          onClick={() => onLike({ questionId, type: "dislike" })}
-        />
-      </Reactions>
+      <Reactions questionId={questionId} like={like} dislike={dislike} onLike={onLike} />
     </FeedCardWrapper>
   );
 }

--- a/src/components/FeedCard/QuestionForm.jsx
+++ b/src/components/FeedCard/QuestionForm.jsx
@@ -1,30 +1,23 @@
 import { useState } from "react";
-import { useParams, useRouteLoaderData } from "react-router-dom";
-import useQuestion from "../../pages/post/components/useQuestion";
 import { Modal, InputTextarea, Avatar } from "@components/ui";
 import usePreventScroll from "@components/Modal/usePreventScroll";
 import styles from "./QuestionForm.module.css";
 
-export function QuestionForm() {
-  const { id } = useParams();
-  const { name, imageSource } = useRouteLoaderData("post");
-  const [question, setQuestion] = useState("");
+export function QuestionForm({ feedOwner, onSubmit, isPending }) {
+  const { name, imageSource } = feedOwner;
+  const [content, setContent] = useState("");
   const [isModal, setIsModal] = useState(false);
-  const { mutate, isPending } = useQuestion();
   const { preventScroll, allowScroll } = usePreventScroll();
 
   const handleToggleModal = () => {
-    setQuestion("");
+    setContent("");
     setIsModal(!isModal);
     isModal ? allowScroll() : preventScroll();
   };
 
   async function handleSubmit(e) {
     e.preventDefault();
-    mutate({
-      id,
-      question,
-    });
+    onSubmit({ content });
     handleToggleModal();
   }
 
@@ -42,11 +35,11 @@ export function QuestionForm() {
           </div>
           <form onSubmit={handleSubmit}>
             <InputTextarea
-              value={question}
-              onChange={(e) => setQuestion(e.target.value)}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
               placeholder="질문을 입력해주세요"
             />
-            <button type="submit" disabled={!question || isPending} className={styles.button}>
+            <button type="submit" disabled={!content || isPending} className={styles.button}>
               질문 보내기
             </button>
           </form>

--- a/src/components/FeedCard/QuestionForm.jsx
+++ b/src/components/FeedCard/QuestionForm.jsx
@@ -10,7 +10,7 @@ export function QuestionForm() {
   const { name, imageSource } = useRouteLoaderData("post");
   const [question, setQuestion] = useState("");
   const [isModal, setIsModal] = useState(false);
-  const { mutate, isPending } = useQuestion(id);
+  const { mutate, isPending } = useQuestion();
   const { preventScroll, allowScroll } = usePreventScroll();
 
   const handleToggleModal = () => {

--- a/src/components/FeedCard/Reactions.jsx
+++ b/src/components/FeedCard/Reactions.jsx
@@ -1,5 +1,15 @@
+import { Reaction } from "@components/Reaction";
 import styles from "./Reactions.module.css";
 
-export function Reactions({ children }) {
-  return <footer className={styles.footer}>{children}</footer>;
+export function Reactions({ questionId, like, dislike, onLike }) {
+  return (
+    <footer className={styles.footer}>
+      <Reaction type="like" count={like} onClick={() => onLike({ questionId, type: "like" })} />
+      <Reaction
+        type="dislike"
+        count={dislike}
+        onClick={() => onLike({ questionId, type: "dislike" })}
+      />
+    </footer>
+  );
 }

--- a/src/components/FeedCard/index.js
+++ b/src/components/FeedCard/index.js
@@ -11,3 +11,4 @@ export * from "./QuestionForm";
 export * from "./PostMessage";
 export * from "./FeedDeleteButton";
 export * from "./AnswerMenu";
+export * from "./AnswerButton";

--- a/src/components/FeedCard/index.js
+++ b/src/components/FeedCard/index.js
@@ -10,3 +10,4 @@ export * from "./Reactions";
 export * from "./QuestionForm";
 export * from "./PostMessage";
 export * from "./FeedDeleteButton";
+export * from "./AnswerMenu";

--- a/src/context/FeedContext.jsx
+++ b/src/context/FeedContext.jsx
@@ -28,13 +28,13 @@ export default function FeedContextProvider({ children }) {
   async function removeFeed(feedId) {
     setIsLoading(true);
 
-    await deleteSubject(feedId);
+    await deleteSubject(Number(feedId));
     setFeeds((prev) => prev.filter((feed) => feed.id !== feedId));
     setIsLoading(false);
   }
 
   function hasFeed(feedId) {
-    return feeds.find((feed) => feed.id === feedId);
+    return feeds.find((feed) => feed.id === Number(feedId));
   }
 
   const ctxValue = { isLoading, feeds, createFeed, removeFeed, hasFeed };

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,8 +1,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App.jsx";
 import "@assets/css/reset.css";
 import "@assets/css/global.css";
+import App from "./App.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>

--- a/src/pages/post/PostAnswerPage.jsx
+++ b/src/pages/post/PostAnswerPage.jsx
@@ -1,14 +1,17 @@
-import { useParams } from "react-router-dom";
+import { useParams, useRouteLoaderData } from "react-router-dom";
 import useQuestions from "./components/useQuestions";
 import { PostMessage } from "@components/FeedCard";
 import Questions from "./components/Questions";
+import useQuestionHandlers from "./components/useQuestionHandlers";
 
 export default function PostAnswerPage() {
   const { id } = useParams();
+  const userInfo = useRouteLoaderData("post");
   const { count, results, ref, error, isLoading, isFetchingNextPage } = useQuestions({
     subjectId: id,
     itemPerPage: 6,
   });
+  const { handlers, isPending } = useQuestionHandlers(id);
 
   if (error) {
     return <PostMessage>질문을 가져오는중에 문제가 생겼습니다.</PostMessage>;
@@ -20,7 +23,14 @@ export default function PostAnswerPage() {
 
   return (
     <>
-      <Questions count={count} data={results} mode="answer" />
+      <Questions
+        mode="answer"
+        count={count}
+        data={results}
+        userInfo={userInfo}
+        handlers={handlers}
+        isPending={isPending}
+      />
       <div ref={ref}>
         {isFetchingNextPage ? <PostMessage>더 불러오는 중입니다...</PostMessage> : ""}
       </div>

--- a/src/pages/post/PostDetailPage.jsx
+++ b/src/pages/post/PostDetailPage.jsx
@@ -1,14 +1,17 @@
-import { useParams } from "react-router-dom";
+import { useParams, useRouteLoaderData } from "react-router-dom";
 import { PostMessage } from "@components/FeedCard";
 import useQuestions from "./components/useQuestions";
 import Questions from "./components/Questions";
+import useQuestionHandlers from "./components/useQuestionHandlers";
 
 export default function PostDetailPage() {
   const { id } = useParams();
+  const userInfo = useRouteLoaderData("post");
   const { count, results, ref, error, isLoading, isFetchingNextPage } = useQuestions({
     subjectId: id,
     itemPerPage: 6,
   });
+  const { handlers, isPending } = useQuestionHandlers(id);
 
   if (error) {
     return <PostMessage>질문을 가져오는중에 문제가 생겼습니다.</PostMessage>;
@@ -20,7 +23,14 @@ export default function PostDetailPage() {
 
   return (
     <>
-      <Questions count={count} data={results} mode="view" />
+      <Questions
+        mode="view"
+        count={count}
+        data={results}
+        userInfo={userInfo}
+        handlers={handlers}
+        isPending={isPending}
+      />
       <div ref={ref}>
         {isFetchingNextPage ? <PostMessage>더 불러오는 중입니다...</PostMessage> : ""}
       </div>

--- a/src/pages/post/components/Questions.jsx
+++ b/src/pages/post/components/Questions.jsx
@@ -1,4 +1,3 @@
-import { useNavigate, useParams, useRouteLoaderData } from "react-router-dom";
 import {
   FeedCard,
   FeedCardList,
@@ -7,77 +6,29 @@ import {
   FeedListWrapper,
   QuestionForm,
 } from "@components/FeedCard";
-import useLike from "./useLike";
-import useAnswer from "./useAnswer";
-import { useFeed } from "@context/FeedContext";
-import { Notify } from "@components/Toast";
-
-export default function Questions({ count, data, mode = "view" }) {
-  const userInfo = useRouteLoaderData("post");
-  const { id: subjectId } = useParams();
-  const { create, update, remove, reject, isPending } = useAnswer();
-  const { mutate: reaction } = useLike();
-  const { removeFeed } = useFeed();
-  const navigate = useNavigate();
-
-  function handleCreate({ questionId, content }) {
-    create({ questionId, content, isRejected: "false" });
-  }
-
-  function handleUpdate({ answerId, content }) {
-    update({
-      answerId,
-      content,
-      isRejected: "false",
-    });
-  }
-
-  function handleDelete({ questionId, answerId }) {
-    remove({ questionId, answerId });
-  }
-
-  function handleReject({ questionId, answerId }) {
-    reject({
-      questionId,
-      answerId,
-      content: "reject",
-      isRejected: true,
-    });
-  }
-
-  function handleLike({ questionId, type }) {
-    reaction({ questionId, type });
-  }
-
-  async function handleDeleteFeed() {
-    try {
-      await removeFeed(subjectId);
-      Notify({ type: "success", message: "피드를 삭제했습니다." });
-      navigate("/", { replace: true });
-    } catch (error) {
-      console.error(error);
-      Notify({ type: "error", message: "문제가 생겨 삭제를 실패했습니다." });
-    }
-  }
-
+export default function Questions({ mode = "view", count, data, userInfo, handlers, isPending }) {
   return (
     <>
-      {mode === "view" ? <QuestionForm /> : <FeedDeleteButton onClick={handleDeleteFeed} />}
+      {mode === "view" ? (
+        <QuestionForm
+          feedOwner={userInfo}
+          onSubmit={handlers.onCreateQuestion}
+          isPending={isPending}
+        />
+      ) : (
+        <FeedDeleteButton onClick={handlers.onDeleteFeed} />
+      )}
       <FeedListWrapper>
         <FeedListHeader count={count} />
         <FeedCardList data={data}>
           {(question) => (
             <FeedCard
               key={question.id}
-              isPending={isPending}
-              question={question}
               mode={mode}
+              question={question}
               feedOwner={userInfo}
-              onCreate={handleCreate}
-              onUpdate={handleUpdate}
-              onDelete={handleDelete}
-              onReject={handleReject}
-              onLike={handleLike}
+              isPending={isPending}
+              {...handlers}
             />
           )}
         </FeedCardList>

--- a/src/pages/post/components/Questions.jsx
+++ b/src/pages/post/components/Questions.jsx
@@ -1,4 +1,5 @@
 import {
+  AnswerButton,
   FeedCard,
   FeedCardList,
   FeedDeleteButton,
@@ -6,15 +7,19 @@ import {
   FeedListWrapper,
   QuestionForm,
 } from "@components/FeedCard";
+
 export default function Questions({ mode = "view", count, data, userInfo, handlers, isPending }) {
   return (
     <>
       {mode === "view" ? (
-        <QuestionForm
-          feedOwner={userInfo}
-          onSubmit={handlers.onCreateQuestion}
-          isPending={isPending}
-        />
+        <>
+          <AnswerButton />
+          <QuestionForm
+            feedOwner={userInfo}
+            onSubmit={handlers.onCreateQuestion}
+            isPending={isPending}
+          />
+        </>
       ) : (
         <FeedDeleteButton onClick={handlers.onDeleteFeed} />
       )}

--- a/src/pages/post/components/useQuestion.js
+++ b/src/pages/post/components/useQuestion.js
@@ -6,7 +6,7 @@ export default function useQuestion() {
   const queryClient = useQueryClient();
 
   const { mutate, isPending } = useMutation({
-    mutationFn: ({ id, question }) => createQuestion(id, question),
+    mutationFn: ({ subjectId, content }) => createQuestion(subjectId, content),
     onSuccess: async (data) => {
       Notify({
         type: "success",

--- a/src/pages/post/components/useQuestionHandlers.js
+++ b/src/pages/post/components/useQuestionHandlers.js
@@ -1,0 +1,73 @@
+import { useNavigate } from "react-router-dom";
+import { useFeed } from "@context/FeedContext";
+import useAnswer from "./useAnswer";
+import useLike from "./useLike";
+import useQuestion from "./useQuestion";
+import { Notify } from "@components/Toast";
+
+export default function useQuestionHandlers(subjectId) {
+  const { mutate: question, isPending: isQuestionPending } = useQuestion();
+  const { create, update, remove, reject, isPending: isAnswerPending } = useAnswer();
+  const { mutate: reaction } = useLike();
+  const { removeFeed, isLoading: isFeedPending } = useFeed();
+  const navigate = useNavigate();
+
+  function handleCreateQuestion({ content }) {
+    question({ subjectId, content });
+  }
+
+  function handleCreateAnswer({ questionId, content }) {
+    create({ questionId, content, isRejected: "false" });
+  }
+
+  function handleUpdateAnswer({ answerId, content }) {
+    update({
+      answerId,
+      content,
+      isRejected: "false",
+    });
+  }
+
+  function handleDeleteAnswer({ questionId, answerId }) {
+    remove({ questionId, answerId });
+  }
+
+  function handleRejectAnswer({ questionId, answerId }) {
+    reject({
+      questionId,
+      answerId,
+      content: "reject",
+      isRejected: true,
+    });
+  }
+
+  function handleLike({ questionId, type }) {
+    reaction({ questionId, type });
+  }
+
+  async function handleDeleteFeed() {
+    try {
+      await removeFeed(subjectId);
+      Notify({ type: "success", message: "피드를 삭제했습니다." });
+      navigate("/", { replace: true });
+    } catch (error) {
+      console.error(error);
+      Notify({ type: "error", message: "문제가 생겨 삭제를 실패했습니다." });
+    }
+  }
+
+  const isPending = isQuestionPending || isAnswerPending || isFeedPending;
+
+  return {
+    handlers: {
+      onCreateQuestion: handleCreateQuestion,
+      onCreateAnswer: handleCreateAnswer,
+      onUpdateAnswer: handleUpdateAnswer,
+      onDeleteAnswer: handleDeleteAnswer,
+      onRejectAnswer: handleRejectAnswer,
+      onLike: handleLike,
+      onDeleteFeed: handleDeleteFeed,
+    },
+    isPending,
+  };
+}


### PR DESCRIPTION
## #️⃣ 이슈

- close #129 

## 📝 작업 내용
피드카드 내부에 들어있는 데이터 핸들링 훅들을 하나의 통합된 훅으로 모아서
질문, 답편 페이지 진입부에서 선언하여, 리스트 컴포넌트에게 주입하는 형식으로 개선했습니다.
- 컴포넌트들이 데이터 랜더링에만 집중할 수 있도록 개선했어요
- 훅을 이용해 피드 주인이면 답변하러가기 버튼이 보이도록 했어요

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
- main.jsx에서 reset,global의 임포트 순서가 app.jsx보다 밑이라서 스타일 오버라이딩이 되지않아 수정해두었습니다. (a tag 스타일링을 하는데 우선순위가 잘못되어있어서 적용이 안되더군욧)