### PR TITLE
Design(#134) : dropdown css 개선

### DIFF
--- a/src/components/Dropdown/MoreMenu.module.css
+++ b/src/components/Dropdown/MoreMenu.module.css
@@ -52,6 +52,11 @@
   color: var(--color-blue);
 }
 
+.item:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 @keyframes show {
   from {
     opacity: 0;

--- a/src/pages/sample/components/ChankiSample.jsx
+++ b/src/pages/sample/components/ChankiSample.jsx
@@ -99,7 +99,9 @@ export default function ChankiSample() {
           <MoreMenu.Item onClick={() => alert("hi")} icon="edit">
             수정하기
           </MoreMenu.Item>
-          <MoreMenu.Item icon="close">삭제하기</MoreMenu.Item>
+          <MoreMenu.Item icon="close" disabled>
+            삭제하기
+          </MoreMenu.Item>
         </MoreMenu>
 
         {/* 기본 사용형태 (최소 너비로 셋팅이 됩니다.) */}


### PR DESCRIPTION
## #️⃣ 이슈

- close #134

## 📝 작업 내용
MoreMenu의 항목들에 disabled가 있을경우의 css를 추가했습니다.
(select는 만들었는데, Moremenu쪽이 빠졋네요)
- 투명도 조절 및 not-allowed 마우스커서로 변경

## 📸 결과물
<img width="188" alt="image" src="https://github.com/user-attachments/assets/b46f9dd7-ca0f-4951-86a0-25c222c8536e" />

## 👩‍💻 공유 포인트 및 논의 사항
