### PR TITLE
Feat(#139): 질문리스트페이지(/post/{subjectId}) 접속시 최근방문 로그 저장

### DIFF
--- a/src/context/FeedContext.jsx
+++ b/src/context/FeedContext.jsx
@@ -1,11 +1,15 @@
 import { createSubject, deleteSubject } from "@service/Subject";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
 
 const FeedContext = createContext();
 
 export const useFeed = () => useContext(FeedContext);
 
 export default function FeedContextProvider({ children }) {
+  const [visited, setVisited] = useState(() => {
+    const saved = localStorage.getItem("visited");
+    return saved ? JSON.parse(saved) : [];
+  });
   const [feeds, setFeeds] = useState(() => {
     const saved = localStorage.getItem("feeds");
     return saved ? JSON.parse(saved) : [];
@@ -16,28 +20,60 @@ export default function FeedContextProvider({ children }) {
     localStorage.setItem("feeds", JSON.stringify(feeds));
   }, [feeds]);
 
-  async function createFeed(name) {
+  useEffect(() => {
+    localStorage.setItem("visited", JSON.stringify(visited));
+  }, [visited]);
+
+  const createFeed = useCallback(async (name) => {
     setIsLoading(true);
 
     const response = await createSubject({ name });
     setFeeds((prev) => [response, ...prev]);
     setIsLoading(false);
     return response;
-  }
+  }, []);
 
-  async function removeFeed(feedId) {
+  const removeFeed = useCallback(async (feedId) => {
     setIsLoading(true);
 
     await deleteSubject(Number(feedId));
     setFeeds((prev) => prev.filter((feed) => feed.id !== feedId));
     setIsLoading(false);
-  }
+  }, []);
 
-  function hasFeed(feedId) {
-    return feeds.find((feed) => feed.id === Number(feedId));
-  }
+  const hasFeed = useCallback(
+    (feedId) => {
+      return feeds.find((feed) => feed.id === Number(feedId));
+    },
+    [feeds],
+  );
 
-  const ctxValue = { isLoading, feeds, createFeed, removeFeed, hasFeed };
+  const saveVisited = useCallback(
+    (feedData) => {
+      if (visited.find((feed) => feed.id === feedData.id)) return;
+
+      setVisited((prev) => {
+        const filterd = prev.filter((item) => item.id !== feedData.id);
+        return [feedData, ...filterd].slice(0, 4);
+      });
+    },
+    [feeds],
+  );
+
+  const clearVisited = useCallback(() => {
+    setVisited([]);
+  }, []);
+
+  const ctxValue = {
+    isLoading,
+    feeds,
+    createFeed,
+    removeFeed,
+    hasFeed,
+    visited,
+    saveVisited,
+    clearVisited,
+  };
 
   return <FeedContext.Provider value={ctxValue}>{children}</FeedContext.Provider>;
 }

--- a/src/context/FeedContext.jsx
+++ b/src/context/FeedContext.jsx
@@ -57,7 +57,7 @@ export default function FeedContextProvider({ children }) {
         return [feedData, ...filterd].slice(0, 4);
       });
     },
-    [feeds],
+    [visited],
   );
 
   const clearVisited = useCallback(() => {

--- a/src/pages/post/PostDetailPage.jsx
+++ b/src/pages/post/PostDetailPage.jsx
@@ -1,4 +1,6 @@
+import { useEffect } from "react";
 import { useParams, useRouteLoaderData } from "react-router-dom";
+import { useFeed } from "@context/FeedContext";
 import { PostMessage } from "@components/FeedCard";
 import useQuestions from "./components/useQuestions";
 import Questions from "./components/Questions";
@@ -12,6 +14,13 @@ export default function PostDetailPage() {
     itemPerPage: 6,
   });
   const { handlers, isPending } = useQuestionHandlers(id);
+  const { saveVisited } = useFeed();
+
+  useEffect(() => {
+    if (userInfo) {
+      saveVisited(userInfo);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (error) {
     return <PostMessage>질문을 가져오는중에 문제가 생겼습니다.</PostMessage>;


### PR DESCRIPTION
## #️⃣ 이슈

- close #139 

## 📝 작업 내용
- 기존에 만든 useFeed 컨텍스트에 기능을 추가했습니다.
  - visited : 최근방문 리스트
  - saveVisited : 최근방문 리스트 저장 함수
  - clearVisited : 최근방문 리스트 삭제 함수

- /post/{subjectId} 으로 접속시에 saveVisted를 통해 최근방문리스트에 추가하는 행동을 작성해두었습니다.
- 메인이나, 다른페이지에서 최근방문기록을 사용하실분은 useFeed 컨텍스트에서 visited, clearVisited를 꺼내서 활용하시면 됩니다.
    - visited : 최근방문 리스트
    - clearVisited : 최근방문 삭제 기능
 
- 모든 함수에 useCallback을 적용해두었습니다. (혹시나 이 함수를 의존성배열에 넣게 되면 무한랜더링 루프 방지를 위해)

## 📸 결과물
<img width="1566" alt="스크린샷 2024-12-16 오전 10 45 59" src="https://github.com/user-attachments/assets/ac0a904a-1dcf-48ea-bb3f-ece9d5786977" />


## 👩‍💻 공유 포인트 및 논의 사항
