### PR TITLE
Refactor(#147): postList 페이지 반응형 버그 수정, url파라미터 적용 리팩토링

### DIFF
--- a/src/pages/post/components/PostList.jsx
+++ b/src/pages/post/components/PostList.jsx
@@ -3,29 +3,45 @@ import React, { useState, useEffect } from "react";
 import { fetchSubjects } from "@service/Subject";
 import { UserCard, Pagination, Select } from "@components/ui";
 import { getItemsPerPage } from "./itemPerPage";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 
 export default function PostList() {
   const [subjects, setSubjects] = useState([]); // 질문자 목록 상태
   const [totalItems, setTotalItems] = useState(0); // 전체 항목 수
-  const [currentPage, setCurrentPage] = useState(1); // 현재 페이지 상태
-  const [itemsPerPage, setItemsPerPage] = useState(() => getItemsPerPage()); //게으른 초기화 방식
-  const [sort, setSort] = useState("time"); // 정렬 기준 상태 (기본값: 최신순)
+  const [itemsPerPage, setItemsPerPage] = useState(() => getItemsPerPage()); // 화면 크기에 맞는 초기값
+  const [searchParams, setSearchParams] = useSearchParams(); // URL 쿼리 파라미터
+
+  // 현재 페이지와 정렬 기준을 URL에서 가져옴
+  const currentPage = parseInt(searchParams.get("page") || "1", 10); // URL에서 현재 페이지 값 가져오고 없으면 1로 설정
+  const sort = searchParams.get("sort") || "time"; // URL에서 정렬기준 값 가져오기 (기본값: 최신순)
 
   // 화면 크기 변화 감지 및 itemsPerPage 업데이트
   useEffect(() => {
     function handleResize() {
-      setItemsPerPage(getItemsPerPage()); // 화면 크기에 맞는 itemsPerPage 값을 업데이트
+      const newItemsPerPage = getItemsPerPage();
+
+      setItemsPerPage((prevItemsPerPage) => {
+        if (prevItemsPerPage !== newItemsPerPage) {
+          return newItemsPerPage; // 화면 크기가 변경될 때만 itemsPerPage를 업데이트
+        }
+        return prevItemsPerPage;
+      });
+
+      // 페이지 번호 보정
+      setSearchParams((prevParams) => {
+        const maxPage = Math.ceil(totalItems / newItemsPerPage);
+        const currentPage = parseInt(prevParams.get("page") || "1", 10);
+
+        return { ...prevParams, page: currentPage > maxPage ? maxPage : currentPage };
+      });
     }
 
-    // 브라우저의 크기 조정 이벤트 리스너 추가
+    // 이벤트 리스너 등록
     window.addEventListener("resize", handleResize);
 
     // 이벤트 리스너 제거
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []); // 빈 배열로 의존성 설정 (최초 렌더링 시에만 실행)
+    return () => window.removeEventListener("resize", handleResize);
+  }, [totalItems]); // totalItems 의존성 추가
 
   // 질문자 목록 가져오기 함수
   useEffect(() => {
@@ -34,23 +50,29 @@ export default function PostList() {
         const data = await fetchSubjects(currentPage, itemsPerPage, sort);
         setSubjects(data.results); // 받아온 데이터 설정
         setTotalItems(data.count); // 총 데이터 수 설정
+
+        // 페이지 보정 (뒤로 가기 시 최대 페이지 확인)
+        const maxPage = Math.ceil(data.count / itemsPerPage);
+        if (currentPage > maxPage) {
+          setSearchParams({ page: maxPage, sort });
+        }
       } catch (err) {
         console.error("질문자 목록을 불러오는 데 실패했습니다.", err); // 에러 로그
       }
     }
 
     loadSubjects();
-  }, [currentPage, itemsPerPage, sort]); // currentPage, itemsPerPage, sort 변경 시 실행
+  }, [currentPage, itemsPerPage, sort]); // 상태 변경 시 실행
 
   // 페이지 변경 함수
   function handlePageChange(page) {
-    setCurrentPage(page); // 현재 페이지 변경
+    setSearchParams({ page, sort }); // 현재 페이지 변경
   }
 
   // 정렬 기준 변경 함수
   function handleSortChange(value) {
     setSort(value); // 정렬 기준 업데이트
-    setCurrentPage(1); // 정렬 기준 변경 시 첫 페이지로 이동
+    setSearchParams({ page: 1, sort: value }); // 정렬 기준 변경 시 첫 페이지로 이동
   }
 
   // 데이터 출력

--- a/src/pages/post/components/PostList.jsx
+++ b/src/pages/post/components/PostList.jsx
@@ -71,7 +71,6 @@ export default function PostList() {
 
   // 정렬 기준 변경 함수
   function handleSortChange(value) {
-    setSort(value); // 정렬 기준 업데이트
     setSearchParams({ page: 1, sort: value }); // 정렬 기준 변경 시 첫 페이지로 이동
   }
 


### PR DESCRIPTION
## #️⃣ 이슈

- close #147

## 📝 작업 내용
- 화면 사이즈 변경 시 페이지 보정 로직 추가
- URL 파라미터를 통해 페이지 번호와 정렬 기준 유지
## 📸 결과물
-변경전
![image](https://github.com/user-attachments/assets/4cfbdcec-d1dc-4a9d-8413-4ceb4d9ed43d)
-변경 후
![image](https://github.com/user-attachments/assets/a83648b4-ab1a-4526-bd16-90f70a34601d)

-url 파라미터 적용
![image](https://github.com/user-attachments/assets/299e33bf-0764-4695-945b-2b57cb900ecc)



## 👩‍💻 공유 포인트 및 논의 사항
반응형 버그 수정 후 테스트 과정 중  mobile 사이즈에서 카드를 클릭하여 피드로 이동 후 pc사이즈로 변경하고 뒤로가기를 누르면
페이지 번호를 기억하여 해당 페이지로 돌아가는 과정에서 질문자가 있는 카드로 돌아가는것이 아닌 단순 페이지 번호로 돌아가고있습니다. 추후에 질문자id를 url파라미터에 추가하여 뒤로가기를 누르면 해당 질문자의 페이지로 뒤로갈 수 있게 변경 해보겠습니다.
