### PR TITLE
Feat(#161): 상세페이지 헤더 - 버튼 공용 컴포넌트로 교체

### DIFF
--- a/src/components/ui.js
+++ b/src/components/ui.js
@@ -7,4 +7,4 @@ export * from "./Pagination";
 export * from "./Reaction";
 export * from "./Input";
 export * from "./UserCard";
-//export * from "./Button";
+export * from "./Button";

--- a/src/pages/post/components/PostDetailHeader.jsx
+++ b/src/pages/post/components/PostDetailHeader.jsx
@@ -1,6 +1,6 @@
 import { useLoaderData, Link } from "react-router-dom";
 import { useEffect } from "react";
-import { Avatar, Icon, ShareButton } from "@components/ui";
+import { Avatar, ShareButton } from "@components/ui";
 import { copyUrl, shareKakao, shareFacebook } from "@util/shareUtils";
 import styles from "./PostDetailHeader.module.css";
 import logo from "/src/assets/img/common/logo.svg";

--- a/src/pages/post/components/PostDetailHeader.jsx
+++ b/src/pages/post/components/PostDetailHeader.jsx
@@ -1,9 +1,9 @@
 import { useLoaderData, Link } from "react-router-dom";
-import { Avatar, Icon } from "@components/ui";
+import { useEffect } from "react";
+import { Avatar, Icon, ShareButton } from "@components/ui";
 import { copyUrl, shareKakao, shareFacebook } from "@util/shareUtils";
 import styles from "./PostDetailHeader.module.css";
 import logo from "/src/assets/img/common/logo.svg";
-import { useEffect } from "react";
 
 export default function PostDetailHeader() {
   //const data = useLoaderData(); // 이렇게 쓰셔도 되고, 분해하셔도 되욤
@@ -32,15 +32,28 @@ export default function PostDetailHeader() {
         <h1>{name}</h1>
       </div>
       <div className={styles.sns}>
-        <button className={styles.sns__link} onClick={copyUrl}>
-          <Icon name="link" color="var(--color-white)" size="18" />
-        </button>
+        <ShareButton
+          color="var(--color-primary-400)"
+          icon="link"
+          iconColor="var(--color-white)"
+          onClick={copyUrl}
+        ></ShareButton>
+        {/* <ShareButton
+          color="var(--color-yellow)"
+          icon="kakao"
+          iconColor="var(--color-black)"
+          id="kakao-link-btn"
+          onClick={shareKakao}
+        ></ShareButton> */}
         <button className={styles.sns__kakao} id="kakao-link-btn" onClick={shareKakao}>
           <Icon name="kakao" color="var(--color-black)" size="18" />
         </button>
-        <button className={styles.sns__facebook} onClick={shareFacebook}>
-          <Icon name="facebook" color="var(--color-white)" size="18" />
-        </button>
+        <ShareButton
+          color="#1877F2"
+          icon="facebook"
+          iconColor="var(--color-white)"
+          onClick={shareFacebook}
+        ></ShareButton>
       </div>
     </div>
   );

--- a/src/pages/post/components/PostDetailHeader.jsx
+++ b/src/pages/post/components/PostDetailHeader.jsx
@@ -38,16 +38,13 @@ export default function PostDetailHeader() {
           iconColor="var(--color-white)"
           onClick={copyUrl}
         ></ShareButton>
-        {/* <ShareButton
+        <ShareButton
           color="var(--color-yellow)"
           icon="kakao"
           iconColor="var(--color-black)"
           id="kakao-link-btn"
           onClick={shareKakao}
-        ></ShareButton> */}
-        <button className={styles.sns__kakao} id="kakao-link-btn" onClick={shareKakao}>
-          <Icon name="kakao" color="var(--color-black)" size="18" />
-        </button>
+        ></ShareButton>
         <ShareButton
           color="#1877F2"
           icon="facebook"


### PR DESCRIPTION
## #️⃣ 이슈

- close #161

## 📝 작업 내용
상세페이지 헤더 - 버튼 공용 컴포넌트로 교체

## 📸 결과물
![image](https://github.com/user-attachments/assets/fd131be6-0577-4b5e-b8a7-f123fbb07182)

## 👩‍💻 공유 포인트 및 논의 사항
- [카카오 공유하기 이슈]
공용 컴포넌트를 써서 prop으로 내려주니 shareUtils.js가 들어가 있지 않아 작동하지 않습니다.
그렇다고 공용 컴포넌트에 kakao 스크립트만 추가 하자니 공유하기 스크립트가 흩어져서 유지보수가 힘들 것 같습니다.
의견 부탁드립니다 :)  
