### PR TITLE
Feat(#176,#180): 답변하러가기 버튼 상세페이지 헤더로 변경, 생성일 추가

### DIFF
--- a/src/components/FeedCard/AnswerButton.jsx
+++ b/src/components/FeedCard/AnswerButton.jsx
@@ -6,7 +6,7 @@ export function AnswerButton() {
   const { id } = useParams();
   const { hasFeed } = useFeed();
   const isOwner = hasFeed(id);
-  const isQuestionPage = useMatch("/post/:id");
+  const isQuestionPage = useMatch("/post/:id"); // 분기 처리
 
   if (!isOwner || !isQuestionPage) return null;
 

--- a/src/components/FeedCard/AnswerButton.jsx
+++ b/src/components/FeedCard/AnswerButton.jsx
@@ -1,13 +1,14 @@
 import { useFeed } from "@context/FeedContext";
-import { Link, useParams } from "react-router-dom";
+import { Link, useMatch, useParams } from "react-router-dom";
 import styles from "./AnswerButton.module.css";
 
 export function AnswerButton() {
   const { id } = useParams();
   const { hasFeed } = useFeed();
   const isOwner = hasFeed(id);
+  const isQuestionPage = useMatch("/post/:id");
 
-  if (!isOwner) return null;
+  if (!isOwner || !isQuestionPage) return null;
 
   return (
     <div className={styles.controls}>

--- a/src/components/FeedCard/AnswerButton.module.css
+++ b/src/components/FeedCard/AnswerButton.module.css
@@ -1,13 +1,6 @@
-.controls {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: -2em;
-}
-
-a.button {
-  padding: 1em 0;
-  margin-bottom: 1em;
+.controls a.button {
+  display: inline-block;
+  margin-top: 1.5rem;
   color: var(--color-primary-400);
   text-decoration: underline;
 }

--- a/src/pages/post/components/PostDetailHeader.jsx
+++ b/src/pages/post/components/PostDetailHeader.jsx
@@ -1,13 +1,15 @@
 import { useLoaderData, Link } from "react-router-dom";
 import { Avatar, Icon } from "@components/ui";
 import { copyUrl, shareKakao, shareFacebook } from "@util/shareUtils";
+import { fromNow } from "@util/format";
+import { AnswerButton } from "@components/FeedCard";
 import styles from "./PostDetailHeader.module.css";
 import logo from "/src/assets/img/common/logo.svg";
 import { useEffect } from "react";
 
 export default function PostDetailHeader() {
   //const data = useLoaderData(); // 이렇게 쓰셔도 되고, 분해하셔도 되욤
-  const { name, imageSource } = useLoaderData();
+  const { name, imageSource, createdAt } = useLoaderData();
 
   // 카카오톡 공유하기
   useEffect(() => {
@@ -31,6 +33,8 @@ export default function PostDetailHeader() {
       <div className={styles.title}>
         <h1>{name}</h1>
       </div>
+      <div className={styles.meta}>생성일 {fromNow(createdAt)}</div>
+      <AnswerButton />
       <div className={styles.sns}>
         <button className={styles.sns__link} onClick={copyUrl}>
           <Icon name="link" color="var(--color-white)" size="18" />

--- a/src/pages/post/components/PostDetailHeader.module.css
+++ b/src/pages/post/components/PostDetailHeader.module.css
@@ -3,21 +3,13 @@
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  margin: 0 auto 5.4rem;
+  margin: 0 auto 4rem;
   padding-top: 5rem;
   width: 100%;
   max-width: 1200px;
   background-image: url("/src/assets/img/page-detail/header-bg.svg");
   background-repeat: no-repeat;
   background-position: top center;
-}
-
-.header__wrapper > div {
-  margin-bottom: 1.2rem;
-}
-
-.header__wrapper > div:last-child {
-  margin-bottom: 0;
 }
 
 .logo img {
@@ -28,18 +20,25 @@
   width: 13.6rem;
 }
 
+.title {
+  margin-top: 1.5rem;
+}
+
 .title h1 {
   font-size: var(--font-size-h2);
 }
 
-.sns {
-  display: flex;
+.meta {
+  margin-top: 1.5rem;
+  font-size: 1.5rem;
+  color: var(--color-primary-300);
 }
 
 .sns {
   display: flex;
   justify-content: center;
   gap: 1.2rem;
+  margin-top: 3rem;
 }
 
 .sns button {

--- a/src/pages/post/components/PostDetailLayout.module.css
+++ b/src/pages/post/components/PostDetailLayout.module.css
@@ -3,8 +3,11 @@
 }
 
 .detail__header {
-  margin-bottom: 5.4rem;
-  background-image: linear-gradient(to bottom, var(--color-white) 65%, var(--color-gray-200) 35%);
+  background-image: linear-gradient(
+    to bottom,
+    var(--color-white) 54.5%,
+    var(--color-gray-200) 45.5%
+  );
 }
 
 .detail__list {

--- a/src/pages/post/components/Questions.jsx
+++ b/src/pages/post/components/Questions.jsx
@@ -1,5 +1,4 @@
 import {
-  AnswerButton,
   FeedCard,
   FeedCardList,
   FeedDeleteButton,
@@ -13,7 +12,6 @@ export default function Questions({ mode = "view", count, data, userInfo, handle
     <>
       {mode === "view" ? (
         <>
-          <AnswerButton />
           <QuestionForm
             feedOwner={userInfo}
             onSubmit={handlers.onCreateQuestion}


### PR DESCRIPTION
## #️⃣ 이슈

- close #176 
- close #180

## 📝 작업 내용
- <답변하러가기> 버튼 상세페이지 헤더로 이동
- 상세페이지 헤더에 생성일 시간 표시 기능 추가

## 📸 결과물
![image](https://github.com/user-attachments/assets/8db4d535-1148-4205-b67e-1619b6f2769c)

## 👩‍💻 공유 포인트 및 논의 사항
