### PR TITLE
Refector(#185): 공용 컴포넌트 modal 개선

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,60 +1,62 @@
 import { motion } from "motion/react";
 import { Icon } from "@components/Icon";
 import styles from "./Modal.module.css";
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { forwardRef, useImperativeHandle, useState } from "react";
 import usePreventScroll from "./usePreventScroll";
 import { createPortal } from "react-dom";
 
 /**
- * @param {object} props
- * @param {function} props.handleToggleModal - 모달 토글 (열기/닫기)
- * @param {string} props.title - 모달 타이틀
- * @param {string} props.icon - 모달 아이콘명
- * @param {children} props.children - 모달 콘텐츠
+ * 모달 오버레이 애니메이션의 상태를 정의한 객체입니다.
+ * @type {Object}
  */
-
 const overlay = {
   hidden: { opacity: 0 },
   show: { opacity: 1 },
 };
 
+/**
+ * 모달 컨테이너 애니메이션의 상태를 정의한 객체입니다.
+ * @type {Object}
+ */
 const container = {
   hidden: { opacity: 0, scale: 0.4 },
   show: { opacity: 1, scale: 1 },
 };
 
+/**
+ * 모달 컴포넌트입니다. 모달 오버레이와 콘텐츠를 렌더링하며,
+ * 부모 컴포넌트에서 제공된 메서드를 통해 모달을 열고 닫을 수 있습니다.
+ *
+ * @component
+ * @example
+ * const modalRef = useRef(null);
+ * <Modal ref={modalRef} title="모달 제목" icon="message">모달 내용</Modal>;
+ *
+ * modalRef.current.open(); // 모달 열기
+ * modalRef.current.close(); // 모달 닫기
+ *
+ * @param {Object} props - Modal 컴포넌트의 속성입니다.
+ * @param {string} [props.title] - 모달 헤더에 표시할 제목입니다.
+ * @param {string} [props.icon] - 헤더에 표시할 아이콘의 이름입니다. 예: "info", "close" 등.
+ * @param {React.ReactNode} [props.children] - 모달의 본문에 표시할 콘텐츠입니다.
+ *
+ * @returns {React.Component|null} 열려있을 경우 렌더링되는 Modal 컴포넌트를 반환하고, 그렇지 않으면 null을 반환합니다.
+ */
 export const Modal = forwardRef(function Modal({ title, icon, children }, ref) {
+  /**
+   * 모달의 열림/닫힘 상태를 관리하는 상태입니다.
+   * @type {boolean}
+   */
   const [isOpen, setIsOpen] = useState(false);
-  const scrollPositionRef = useRef(0);
-  //const { preventScroll, allowScroll } = usePreventScroll();
 
-  useEffect(() => {
-    if (isOpen) {
-      scrollPositionRef.current = window.scrollY;
+  /**
+   * 모달이나 특정 UI 요소가 열릴 때 스크롤을 잠그는 커스텀 훅입니다.
+   */
+  usePreventScroll(isOpen);
 
-      document.body.style.position = "fixed";
-      document.body.style.width = "100%";
-      document.body.style.top = `-${scrollPositionRef.current}px`;
-      document.body.style.overflowY = "hidden";
-    } else {
-      document.body.style.position = "";
-      document.body.style.width = "";
-      document.body.style.top = "";
-      document.body.style.overflowY = "";
-      window.scrollTo(0, scrollPositionRef.current);
-    }
-
-    return () => {
-      document.body.style.position = "";
-      document.body.style.width = "";
-      document.body.style.top = "";
-      document.body.style.overflowY = "";
-      if (scrollPositionRef.current) {
-        window.scrollTo(0, scrollPositionRef.current);
-      }
-    };
-  }, [isOpen]);
-
+  /**
+   * 부모 컴포넌트에게 open과 close 메서드를 전달하기 위한 useImperativeHandle 훅 사용
+   */
   useImperativeHandle(ref, function () {
     return {
       open() {
@@ -66,6 +68,7 @@ export const Modal = forwardRef(function Modal({ title, icon, children }, ref) {
     };
   });
 
+  // 모달이 열리지 않으면 아무것도 렌더링하지 않음
   if (!isOpen) {
     return null;
   }

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,7 +1,7 @@
 import { motion } from "motion/react";
 import { Icon } from "@components/Icon";
 import styles from "./Modal.module.css";
-import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import usePreventScroll from "./usePreventScroll";
 import { createPortal } from "react-dom";
 
@@ -25,17 +25,35 @@ const container = {
 
 export const Modal = forwardRef(function Modal({ title, icon, children }, ref) {
   const [isOpen, setIsOpen] = useState(false);
-
-  const { preventScroll, allowScroll } = usePreventScroll();
+  const scrollPositionRef = useRef(0);
+  //const { preventScroll, allowScroll } = usePreventScroll();
 
   useEffect(() => {
     if (isOpen) {
-      preventScroll();
+      scrollPositionRef.current = window.scrollY;
+
+      document.body.style.position = "fixed";
+      document.body.style.width = "100%";
+      document.body.style.top = `-${scrollPositionRef.current}px`;
+      document.body.style.overflowY = "hidden";
     } else {
-      allowScroll();
+      document.body.style.position = "";
+      document.body.style.width = "";
+      document.body.style.top = "";
+      document.body.style.overflowY = "";
+      window.scrollTo(0, scrollPositionRef.current);
     }
-    return () => allowScroll();
-  }, [isOpen, preventScroll, allowScroll]);
+
+    return () => {
+      document.body.style.position = "";
+      document.body.style.width = "";
+      document.body.style.top = "";
+      document.body.style.overflowY = "";
+      if (scrollPositionRef.current) {
+        window.scrollTo(0, scrollPositionRef.current);
+      }
+    };
+  }, [isOpen]);
 
   useImperativeHandle(ref, function () {
     return {

--- a/src/components/Modal/usePreventScroll.js
+++ b/src/components/Modal/usePreventScroll.js
@@ -1,34 +1,51 @@
-import { useState } from "react";
+import { useRef, useEffect } from "react";
 
 /**
- * 스크롤 방지와 현재 스크롤 위치를 반환하는 custom hook
- * 스크롤 막기 함수
- * @function preventScroll
- * 스크롤 원래 상태로 되돌리는 함수 (스크롤 막기 해제)
- * @function allowScroll
+ * 페이지가 열리거나 모달 등의 UI가 열릴 때 페이지 스크롤을 잠그는 커스텀 훅입니다.
+ * `isOpen`이 `true`일 경우 스크롤을 잠그고, `false`일 경우 스크롤을 복원합니다.
+ *
+ * 스크롤이 잠긴 상태에서 페이지를 이동하려고 하면 위치가 고정됩니다.
+ * 모달이나 특정 UI가 닫힐 때 페이지가 원래 있던 위치로 복원됩니다.
+ *
+ * @param {boolean} isOpen - 모달 또는 UI가 열려 있는 상태인지 나타내는 값. `true`일 경우 스크롤을 잠금, `false`일 경우 스크롤을 복원.
+ *
+ * @example
+ * const [isOpen, setIsOpen] = useState(false);
+ * usePreventScroll(isOpen); // 모달이 열릴 때 스크롤을 잠그고, 닫을 때 복원
  */
-const usePreventScroll = () => {
-  const [prevScrollY, setPrevScrollY] = useState(0);
+const usePreventScroll = (isOpen) => {
+  const scrollPositionRef = useRef(0);
 
-  const preventScroll = () => {
-    const currentScrollY = window.scrollY;
-    setPrevScrollY(currentScrollY); // 이전 스크롤 위치를 상태로 저장
+  useEffect(() => {
+    // 스크롤 잠금
+    if (isOpen) {
+      scrollPositionRef.current = window.scrollY;
 
-    document.body.style.position = "fixed";
-    document.body.style.width = "100%";
-    document.body.style.top = `-${currentScrollY}px`; // 현재 스크롤 위치
-    document.body.style.overflowY = "hidden";
-  };
+      document.body.style.position = "fixed";
+      document.body.style.width = "100%";
+      document.body.style.top = `-${scrollPositionRef.current}px`;
+      document.body.style.overflowY = "hidden";
+    } else {
+      // 스크롤 복원
+      document.body.style.position = "";
+      document.body.style.width = "";
+      document.body.style.top = "";
+      document.body.style.overflowY = "";
+      window.scrollTo(0, scrollPositionRef.current); // 원래의 위치로 스크롤 복원
+    }
 
-  const allowScroll = () => {
-    document.body.style.position = "";
-    document.body.style.width = "";
-    document.body.style.top = "";
-    document.body.style.overflowY = "";
-    window.scrollTo(0, prevScrollY); // 이전 스크롤 위치로 이동
-  };
-
-  return { preventScroll, allowScroll };
+    // 컴포넌트 언마운트 시 클린업 작업
+    return () => {
+      document.body.style.position = "";
+      document.body.style.width = "";
+      document.body.style.top = "";
+      document.body.style.overflowY = "";
+      // 스크롤 복원
+      if (scrollPositionRef.current) {
+        window.scrollTo(0, scrollPositionRef.current);
+      }
+    };
+  }, [isOpen]);
 };
 
 export default usePreventScroll;

--- a/src/pages/sample/components/SolSample.jsx
+++ b/src/pages/sample/components/SolSample.jsx
@@ -1,7 +1,6 @@
-import { useState } from "react";
+import { useRef } from "react";
 import { Badge } from "@components/Badge";
 import { Modal } from "@components/Modal";
-import usePreventScroll from "@components/Modal/usePreventScroll";
 import { Toast, Notify } from "@components/Toast";
 
 export default function SolSample() {
@@ -23,13 +22,7 @@ export default function SolSample() {
   /**
    * 모달창
    */
-  const [isModal, setIsModal] = useState(false);
-  const { preventScroll, allowScroll } = usePreventScroll();
-
-  const handleToggleModal = () => {
-    setIsModal(!isModal);
-    isModal ? allowScroll() : preventScroll();
-  };
+  const modelRef = useRef(null);
 
   /**
    * 토스트
@@ -52,23 +45,22 @@ export default function SolSample() {
       <Badge status={status} />
 
       {/* 모달창 */}
-      <button onClick={handleToggleModal}>[ 모달 열기 ]</button>
-      {isModal && (
-        <Modal handleToggleModal={handleToggleModal} title="질문을 작성하세요" icon="message">
-          <p>To. 😸 아초는고양이</p>
-          <div
-            style={{
-              width: "100%",
-              height: "300px",
-              marginTop: "15px",
-              padding: "20px",
-              backgroundColor: "#f9f9f9",
-            }}
-          >
-            질문을 입력해주세요
-          </div>
-        </Modal>
-      )}
+      <button onClick={() => modelRef.current.open()}>[ 모달 열기 ]</button>
+
+      <Modal ref={modelRef} title="질문을 작성하세요" icon="message">
+        <p>To. 😸 아초는고양이</p>
+        <div
+          style={{
+            width: "100%",
+            height: "300px",
+            marginTop: "15px",
+            padding: "20px",
+            backgroundColor: "#f9f9f9",
+          }}
+        >
+          질문을 입력해주세요
+        </div>
+      </Modal>
     </>
   );
 }

--- a/src/pages/sample/components/SolSample.jsx
+++ b/src/pages/sample/components/SolSample.jsx
@@ -22,7 +22,7 @@ export default function SolSample() {
   /**
    * 모달창
    */
-  const modelRef = useRef(null);
+  const modalRef = useRef(null);
 
   /**
    * 토스트
@@ -45,9 +45,9 @@ export default function SolSample() {
       <Badge status={status} />
 
       {/* 모달창 */}
-      <button onClick={() => modelRef.current.open()}>[ 모달 열기 ]</button>
+      <button onClick={() => modalRef.current.open()}>[ 모달 열기 ]</button>
 
-      <Modal ref={modelRef} title="질문을 작성하세요" icon="message">
+      <Modal ref={modalRef} title="질문을 작성하세요" icon="message">
         <p>To. 😸 아초는고양이</p>
         <div
           style={{


### PR DESCRIPTION
## #️⃣ 이슈

- close #185

## 📝 작업 내용
- 공용 컴포넌트 modal 고도화
   - useRef, forwardRef, useImperativeHandle 를 사용

## 📸 결과물
https://github.com/user-attachments/assets/44006b9e-cf72-490b-8c16-9093821902d7

## 👩‍💻 공유 포인트 및 논의 사항
- 모달창이 열릴 때 root 쪽에 넣어지면서 스크롤이 상단으로 올라갑니다
- 해결 방법을 찾고 있으나 찾는 시간이 길어져 의견을 듣고 싶습니다 🥲
