### PR TITLE
Refactor(#172): 반응형 페이지네이션 오류 수정 및 카드리스트 마크업 수정, css 수정

### DIFF
--- a/src/components/UserCard/UserCard.module.css
+++ b/src/components/UserCard/UserCard.module.css
@@ -1,6 +1,4 @@
 .card {
-  max-width: 22rem;
-  min-width: 18.6rem;
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/src/pages/post/PostListPage.jsx
+++ b/src/pages/post/PostListPage.jsx
@@ -1,9 +1,5 @@
 import PostList from "./components/PostList";
 
 export default function PostListPage() {
-  return (
-    <div>
-      <PostList />
-    </div>
-  );
+  return <PostList />;
 }

--- a/src/pages/post/components/PostList.jsx
+++ b/src/pages/post/components/PostList.jsx
@@ -18,44 +18,42 @@ export default function PostList() {
   // 화면 크기 변화 감지 및 itemsPerPage 업데이트
   useEffect(() => {
     function handleResize() {
-      const newItemsPerPage = getItemsPerPage();
+      const newItemsPerPage = getItemsPerPage(); // 화면에 맞는 새로운 itemsPerPage 값 계산
 
+      // itemsPerPage 업데이트
       setItemsPerPage((prevItemsPerPage) => {
         if (prevItemsPerPage !== newItemsPerPage) {
-          return newItemsPerPage; // 화면 크기가 변경될 때만 itemsPerPage를 업데이트
+          // 페이지 재계산: 현재 페이지의 첫 번째 아이템의 인덱스를 유지
+          const firstItemIndex = (currentPage - 1) * prevItemsPerPage;
+
+          // 새 페이지 번호 계산
+          const newPage = Math.min(
+            Math.floor(firstItemIndex / newItemsPerPage) + 1,
+            Math.ceil(totalItems / newItemsPerPage), // 최대 페이지 초과 방지
+          );
+
+          // 페이지 번호가 변경될 때만 setSearchParams 업데이트
+          if (newPage !== currentPage) {
+            setSearchParams({ page: newPage, sort });
+          }
+
+          return newItemsPerPage;
         }
         return prevItemsPerPage;
       });
-
-      // 페이지 번호 보정
-      setSearchParams((prevParams) => {
-        const maxPage = Math.ceil(totalItems / newItemsPerPage);
-        const currentPage = parseInt(prevParams.get("page") || "1", 10);
-
-        return { ...prevParams, page: currentPage > maxPage ? maxPage : currentPage };
-      });
     }
 
-    // 이벤트 리스너 등록
-    window.addEventListener("resize", handleResize);
-
-    // 이벤트 리스너 제거
-    return () => window.removeEventListener("resize", handleResize);
-  }, [totalItems]); // totalItems 의존성 추가
+    window.addEventListener("resize", handleResize); // 화면 리사이즈 이벤트 리스너 등록
+    return () => window.removeEventListener("resize", handleResize); // 이벤트 리스너 제거
+  }, [currentPage, totalItems, sort, setSearchParams]);
 
   // 질문자 목록 가져오기 함수
   useEffect(() => {
     async function loadSubjects() {
       try {
-        const data = await fetchSubjects(currentPage, itemsPerPage, sort);
+        const data = await fetchSubjects(currentPage, itemsPerPage, sort); // API 호출
         setSubjects(data.results); // 받아온 데이터 설정
         setTotalItems(data.count); // 총 데이터 수 설정
-
-        // 페이지 보정 (뒤로 가기 시 최대 페이지 확인)
-        const maxPage = Math.ceil(data.count / itemsPerPage);
-        if (currentPage > maxPage) {
-          setSearchParams({ page: maxPage, sort });
-        }
       } catch (err) {
         console.error("질문자 목록을 불러오는 데 실패했습니다.", err); // 에러 로그
       }
@@ -66,12 +64,12 @@ export default function PostList() {
 
   // 페이지 변경 함수
   function handlePageChange(page) {
-    setSearchParams({ page, sort }); // 현재 페이지 변경
+    setSearchParams({ page, sort }); // 페이지 번호를 URL에 업데이트
   }
 
   // 정렬 기준 변경 함수
   function handleSortChange(value) {
-    setSearchParams({ page: 1, sort: value }); // 정렬 기준 변경 시 첫 페이지로 이동
+    setSearchParams({ page: 1, sort: value }); // 정렬 기준 변경 시 페이지를 1로 설정
   }
 
   // 데이터 출력
@@ -84,21 +82,19 @@ export default function PostList() {
         </Select>
       </div>
 
-      <div className={styles.userCardGrid}>
+      <ul className={styles.userCardList} role="list">
         {subjects.map((subject) => (
-          <Link
-            to={`/post/${subject.id}`} // 각 질문자의 질문 목록 페이지로 이동
-            key={subject.id}
-            aria-label={`${subject.name}의 질문 목록으로 이동`} // 접근성을 위한 설명 추가
-          >
-            <UserCard
-              name={subject.name}
-              imageSource={subject.imageSource || "default.jpg"}
-              questionCount={subject.questionCount}
-            />
-          </Link>
+          <li key={subject.id} role="listitem" className={styles.userCardItem}>
+            <Link to={`/post/${subject.id}`} aria-label={`${subject.name}의 질문 목록으로 이동`}>
+              <UserCard
+                name={subject.name}
+                imageSource={subject.imageSource || "default.jpg"}
+                questionCount={subject.questionCount}
+              />
+            </Link>
+          </li>
         ))}
-      </div>
+      </ul>
 
       <div className={styles.paginationBar}>
         <Pagination

--- a/src/pages/post/components/PostList.jsx
+++ b/src/pages/post/components/PostList.jsx
@@ -75,8 +75,9 @@ export default function PostList() {
   // 데이터 출력
   return (
     <div className={styles.container}>
-      <div className={styles.sortBar}>
-        <Select value={sort} onChange={handleSortChange}>
+      <div className={styles.header}>
+        <h1 className={styles.title}>누구에게 질문할까요?</h1>
+        <Select value={sort} onChange={handleSortChange} className={styles.sortBar}>
           <Select.Option value="name">이름순</Select.Option>
           <Select.Option value="time">최신순</Select.Option>
         </Select>

--- a/src/pages/post/components/PostList.jsx
+++ b/src/pages/post/components/PostList.jsx
@@ -1,9 +1,9 @@
-import styles from "./PostList.module.css";
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 import { fetchSubjects } from "@service/Subject";
 import { UserCard, Pagination, Select } from "@components/ui";
 import { getItemsPerPage } from "./itemPerPage";
-import { Link, useSearchParams } from "react-router-dom";
+import styles from "./PostList.module.css";
 
 export default function PostList() {
   const [subjects, setSubjects] = useState([]); // 질문자 목록 상태

--- a/src/pages/post/components/PostList.module.css
+++ b/src/pages/post/components/PostList.module.css
@@ -1,49 +1,38 @@
 /* 전체 컨테이너 스타일 */
 .container {
-  max-width: 1004px; /* 최대 너비 */
+  max-width: 100.4rem; /* 최대 너비 */
   margin: 0 auto; /* 중앙 정렬 */
-  padding: 0 32px; /* 좌우 여백 */
+  padding: 0 3.2rem; /* 좌우 여백 */
+}
+
+.header {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-20); /* 컴포넌트 간 간격 */
+  align-items: center;
+  gap: 1.8rem;
+  margin-bottom: 3rem;
+}
+
+.title {
+  font-size: var(--font-size-h1);
 }
 
 /* 정렬 바 스타일 */
-.sortBar {
-  display: flex;
-  justify-content: center; /* 가운데 정렬 */
-  margin-bottom: 20px;
-}
 
-.sortBar select {
-  max-width: 80px; /* DropDown 너비 제한 */
+.sortBar {
+  width: 8.2rem; /* DropDown 너비 제한 */
 }
 
 /* 사용자 카드 리스트 */
 .userCardList {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(186px, 1fr)); /* 최소 186px부터 유연하게 확장 */
-  gap: 20px; /* 카드 간격 */
-  margin: 0;
-  padding: 0;
-  list-style: none; /* 기본 ul 스타일 제거 */
-}
-
-/* 사용자 카드 아이템 */
-.userCardItem {
   display: flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box; /* padding 포함한 크기 유지 */
-  max-width: 220px; /* 최대 너비 */
-  min-width: 186px; /* 최소 너비 */
-  width: 100%; /* 부모 grid 셀에 맞춤 */
-  height: 100%; /* 부모 grid 셀에 맞춤 */
+  flex-wrap: wrap;
+  gap: 20px;
+  margin-bottom: 4.6rem;
 }
 
-.userCardItem > * {
-  width: 100%;
-  height: 100%;
+.userCardItem {
+  width: calc(25% - 15px); /* (20 x 3)/ 4 */
 }
 
 /* 페이지네이션 바 스타일 */
@@ -55,21 +44,31 @@
   padding: 0;
 }
 
-/* 태블릿 사이즈 */
-@media (max-width: 1004px) {
-  .userCardList {
-    grid-template-columns: repeat(3, minmax(186px, 1fr)); /* 3단 레이아웃 */
+@media (width < 868px) {
+  .userCardItem {
+    width: calc(33.333% - 13.333px); /* (20 x 2)/ 3 */
   }
 }
 
-/* 모바일 사이즈 */
-@media (max-width: 662px) {
+@media (width < 662px) {
   .container {
-    padding: 0 24px; /* 모바일 여백 조정 */
+    padding: 0 24px;
+  }
+
+  .header {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .title {
+    font-size: var(--font-size-h3);
   }
 
   .userCardList {
-    grid-template-columns: repeat(2, minmax(186px, 1fr)); /* 2단 레이아웃 */
-    gap: 16px; /* 모바일 간격 조정 */
+    gap: 16px;
+  }
+
+  .userCardItem {
+    width: calc(50% - 8px); /* (16x2)/2 */
   }
 }

--- a/src/pages/post/components/PostList.module.css
+++ b/src/pages/post/components/PostList.module.css
@@ -1,58 +1,75 @@
+/* 전체 컨테이너 스타일 */
 .container {
-  max-width: 1200px; /* 중앙 고정 레이아웃 */
-  margin: 0 auto; /* 가운데 정렬 */
-  padding: 32px; /* 좌우 최소 여백 */
+  max-width: 1004px; /* 최대 너비 */
+  margin: 0 auto; /* 중앙 정렬 */
+  padding: 0 32px; /* 좌우 여백 */
   display: flex;
   flex-direction: column;
   gap: var(--spacing-20); /* 컴포넌트 간 간격 */
 }
 
+/* 정렬 바 스타일 */
 .sortBar {
   display: flex;
-  justify-content: center;
+  justify-content: center; /* 가운데 정렬 */
+  margin-bottom: 20px;
 }
 
 .sortBar select {
-  max-width: 80px; /* DropDown 너비 */
+  max-width: 80px; /* DropDown 너비 제한 */
 }
 
-.userCardGrid {
+/* 사용자 카드 리스트 */
+.userCardList {
   display: grid;
-  grid-template-columns: repeat(4, minmax(18.6rem, 1fr)); /* 카드의 최소 너비와 일치 */
-  gap: 2.8rem; /* 카드 간격 */
-  justify-content: space-between; /* 중앙 정렬 */
-  align-items: start;
-  margin: 0 auto; /* 그리드 중앙 정렬 */
+  grid-template-columns: repeat(auto-fill, minmax(186px, 1fr)); /* 최소 186px부터 유연하게 확장 */
+  gap: 20px; /* 카드 간격 */
+  margin: 0;
+  padding: 0;
+  list-style: none; /* 기본 ul 스타일 제거 */
 }
 
+/* 사용자 카드 아이템 */
+.userCardItem {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box; /* padding 포함한 크기 유지 */
+  max-width: 220px; /* 최대 너비 */
+  min-width: 186px; /* 최소 너비 */
+  width: 100%; /* 부모 grid 셀에 맞춤 */
+  height: 100%; /* 부모 grid 셀에 맞춤 */
+}
+
+.userCardItem > * {
+  width: 100%;
+  height: 100%;
+}
+
+/* 페이지네이션 바 스타일 */
 .paginationBar {
   display: flex;
   justify-content: center; /* 페이지네이션 가운데 정렬 */
-  margin-top: 20px; /* 위와 간격 추가 */
-  width: 100%; /* 페이지네이션이 그리드에 맞게 */
-  padding: 0; /* 여백 제거 */
+  margin-top: 20px; /* 위와의 간격 추가 */
+  width: 100%;
+  padding: 0;
 }
 
-/* 태블릿 크기 */
-@media (max-width: 1200px) {
-  .container {
-    padding: 32px; /* 좌우 여백 유지 */
-  }
-
-  .userCardGrid {
-    grid-template-columns: repeat(3, 1fr); /* 한 행에 3개 */
-    gap: 2.8rem; /* 카드 간격 동일 */
+/* 태블릿 사이즈 */
+@media (max-width: 1004px) {
+  .userCardList {
+    grid-template-columns: repeat(3, minmax(186px, 1fr)); /* 3단 레이아웃 */
   }
 }
 
-/* 모바일 크기 */
-@media (max-width: 768px) {
+/* 모바일 사이즈 */
+@media (max-width: 662px) {
   .container {
-    padding: 24px; /* 좌우 여백 조정 */
+    padding: 0 24px; /* 모바일 여백 조정 */
   }
 
-  .userCardGrid {
-    grid-template-columns: repeat(2, 1fr); /* 한 행에 2개 */
-    gap: 2.4rem; /* 카드 간격 모바일 기준 */
+  .userCardList {
+    grid-template-columns: repeat(2, minmax(186px, 1fr)); /* 2단 레이아웃 */
+    gap: 16px; /* 모바일 간격 조정 */
   }
 }

--- a/src/pages/post/components/PostListHeader.jsx
+++ b/src/pages/post/components/PostListHeader.jsx
@@ -18,7 +18,7 @@ export default function PostListHeader() {
           <Icon name="arrowRight" size={18}></Icon>
         </LinkButton>
       </div>
-      <h1 className={styles.title}>누구에게 질문할까요?</h1>
+      {/* <h1 className={styles.title}>누구에게 질문할까요?</h1> */}
     </div>
   );
 }

--- a/src/pages/post/components/itemPerPage.js
+++ b/src/pages/post/components/itemPerPage.js
@@ -1,9 +1,9 @@
 export function getItemsPerPage() {
   const screenWidth = window.innerWidth;
 
-  if (screenWidth <= 768) {
+  if (screenWidth < 662) {
     return 6; // 모바일: 한 페이지에 6개
-  } else if (screenWidth <= 1200) {
+  } else if (screenWidth < 868) {
     return 6; // 태블릿: 한 페이지에 6개
   } else {
     return 8; // PC: 한 페이지에 8개


### PR DESCRIPTION
## #️⃣ 이슈

- close #172 

## 📝 작업 내용
- itemsPerPage 변경 시 현재 페이지의 첫 번째 아이템 인덱스를 기준으로 페이지를 재계산하도록 로직 수정.
- 화면 사이즈에 따라 정확한 페이지 번호가 유지되도록 페이지 보정 로직 추가.
- 정렬 기준 변경 시 URL 파라미터를 통해 페이지를 1번으로 초기화.
- ul과 li 구조 마크업 적용 (시맨틱 마크업 개선).
- 스타일 상 충돌을 최소화하기 위해 UserCard 내부 CSS와 부모 컨테이너 CSS 분리 관리.
- PC/태블릿/모바일 해상도에 따라 4단 → 3단 → 2단으로 카드 레이아웃 조정.
- 카드의 최소 너비 186px 유지, 최대 너비 유연 확장 (minmax 적용).
- 모바일에서 gap을 줄이고 좌우 여백을 24px로 조정.
## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
아직도 미세하게 스타일과 반응형에서 오류가 있는것같습니다. 최종 수정까지 하려 했으나 우선 큰 오류부터 잡고 추가적으로 수정하겠습니다.