### PR TITLE
Refactor: 메인페이지 css조정 및 입력폼 글자제한 구현

### DIFF
--- a/src/pages/main/MainPage.jsx
+++ b/src/pages/main/MainPage.jsx
@@ -15,7 +15,7 @@ export default function MainPage() {
       <div className={styles.header}>
         <div className={styles.link}>
           <LinkButton onClick={() => navigate(`/list`)}>
-            답변하러 가기 <Icon name="arrowRight" size={18}></Icon>
+            질문하러 가기 <Icon name="arrowRight" size={18}></Icon>
           </LinkButton>
         </div>
       </div>

--- a/src/pages/main/MainPage.module.css
+++ b/src/pages/main/MainPage.module.css
@@ -31,8 +31,17 @@
 }
 
 .section {
+  width: 40rem;
+  height: 17.2rem;
+  margin: var(--spacing-24) auto 0;
   order: 2;
   z-index: 1;
+
+  @media (max-width: 767px) {
+    width: 30.5rem;
+    height: 15.6rem;
+    margin: 0 auto;
+  }
 }
 
 .lottie {

--- a/src/pages/main/components/MainPageInputForm.jsx
+++ b/src/pages/main/components/MainPageInputForm.jsx
@@ -22,6 +22,10 @@ export default function MainPageInputForm() {
     e.preventDefault();
     try {
       // Input값 유효성 검증
+      if (trimmedName.length > 12) {
+        Notify({ type: "error", message: "이름은 12자 미만으로 입력해주세요." });
+        return;
+      }
       if (name.trim()) {
         const data = await createFeed(trimmedName);
 

--- a/src/pages/main/components/MainPageInputForm.module.css
+++ b/src/pages/main/components/MainPageInputForm.module.css
@@ -1,6 +1,4 @@
 .form {
-  width: 40rem;
-  height: 17.2rem;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -8,6 +6,10 @@
   padding: var(--spacing-34);
   border-radius: var(--border-radius-lg);
   background-color: var(--color-white);
+
+  @media (max-width: 767px) {
+    padding: var(--spacing-24);
+  }
 }
 
 .button {


### PR DESCRIPTION
## #️⃣ 이슈

- close #186 , #196 , #197 

## 📝 작업 내용
 - 입력폼에 입력하는 이름의 글자수 제한 (12글자).
 - 입력폼의 위치를 로고로부터 (margin-top)24px 조정.
 - 반응형으로 화면이 작아졌을때 입력폼 크기도 줄어들게 구현.
 - 상단 페이지 버튼의 텍스트를 "질문하러 가기"로 변경

## 📸 결과물
 - 글자수 제한:
 
![스크린샷 2024-12-17 오후 9 07 07](https://github.com/user-attachments/assets/3f25b722-6381-42ed-be3c-7128390266a9)
<img width="1146" alt="스크린샷 2024-12-17 오후 9 06 43" src="https://github.com/user-attachments/assets/6b444efc-5ff0-4b34-820a-d5602567d4bd" />
