### PR TITLE
Fix(#213): 답변 작성시간이 미래로 나오는 현상 수정 (몇초후)

### DIFF
--- a/src/util/format.js
+++ b/src/util/format.js
@@ -6,5 +6,12 @@ dayjs.extend(relativeTime);
 dayjs.locale("ko");
 
 export function fromNow(date) {
-  return dayjs(date).fromNow();
+  const now = dayjs();
+  const formatDate = dayjs(date);
+
+  if (formatDate.isSame(now) || formatDate.isAfter(now)) {
+    return "방금전";
+  }
+
+  return formatDate.fromNow();
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #213 

## 📝 작업 내용
분명 어제까지, 답변 작성을 하면 날아오는 데이터의 작성일이 '몇초후'라고 미래로 떳었는데,
오늘은 괜찮네요. 그래도 혹시 몰라서 데이터의 작성일이 지금이거나, 미래이면 '방금전'이라고 바꿔서 나가도록 수정해두었습니다.

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
