### PR TITLE
Feat(#216): 개별 질문 삭제 기능 추가

### DIFF
--- a/src/components/FeedCard/AnswerMenu.jsx
+++ b/src/components/FeedCard/AnswerMenu.jsx
@@ -1,6 +1,6 @@
 import { MoreMenu } from "@components/Dropdown";
 
-export function AnswerMenu({ mode, answer, onReject, onModify, onDelete }) {
+export function AnswerMenu({ mode, answer, onReject, onModify, onDelete, onDeleteQuestion }) {
   if (mode === "view") return null;
 
   return (
@@ -12,7 +12,10 @@ export function AnswerMenu({ mode, answer, onReject, onModify, onDelete }) {
         수정하기
       </MoreMenu.Item>
       <MoreMenu.Item icon="close" onClick={onDelete} disabled={!answer}>
-        삭제하기
+        답변삭제
+      </MoreMenu.Item>
+      <MoreMenu.Item icon="close" onClick={onDeleteQuestion}>
+        질문삭제
       </MoreMenu.Item>
     </MoreMenu>
   );

--- a/src/components/FeedCard/FeedCard.jsx
+++ b/src/components/FeedCard/FeedCard.jsx
@@ -10,6 +10,7 @@ export function FeedCard({
   onUpdateAnswer,
   onDeleteAnswer,
   onRejectAnswer,
+  onDeleteQuestion,
   onLike,
 }) {
   const { id: questionId, content, like, dislike, createdAt, answer } = question;
@@ -28,9 +29,17 @@ export function FeedCard({
   }
 
   function handleDelete() {
+    if (!confirm("정말 답변을 삭제할까요?")) return;
     onDeleteAnswer({
       questionId,
       answerId: answer?.id,
+    });
+  }
+
+  function handleDeleteQuestion() {
+    if (!confirm("정말 질문을 삭제할까요?")) return;
+    onDeleteQuestion({
+      questionId,
     });
   }
 
@@ -43,6 +52,7 @@ export function FeedCard({
           onReject={handleReject}
           onModify={handleModify}
           onDelete={handleDelete}
+          onDeleteQuestion={handleDeleteQuestion}
         />
       </Question>
       <Answer

--- a/src/pages/post/components/useQuestionHandlers.js
+++ b/src/pages/post/components/useQuestionHandlers.js
@@ -6,14 +6,22 @@ import useQuestion from "./useQuestion";
 import { Notify } from "@components/Toast";
 
 export default function useQuestionHandlers(subjectId) {
-  const { mutate: question, isPending: isQuestionPending } = useQuestion(subjectId);
+  const {
+    create: createQuestion,
+    remove: removeQuestion,
+    isPending: isQuestionPending,
+  } = useQuestion(subjectId);
   const { create, update, remove, reject, isPending: isAnswerPending } = useAnswer(subjectId);
   const { mutate: reaction } = useLike(subjectId);
   const { removeFeed, isLoading: isFeedPending } = useFeed();
   const navigate = useNavigate();
 
   function handleCreateQuestion({ content }) {
-    question({ content });
+    createQuestion({ content });
+  }
+
+  function handleDeleteQuestion({ questionId }) {
+    removeQuestion({ questionId });
   }
 
   function handleCreateAnswer({ questionId, content }) {
@@ -63,6 +71,7 @@ export default function useQuestionHandlers(subjectId) {
   return {
     handlers: {
       onCreateQuestion: handleCreateQuestion,
+      onDeleteQuestion: handleDeleteQuestion,
       onCreateAnswer: handleCreateAnswer,
       onUpdateAnswer: handleUpdateAnswer,
       onDeleteAnswer: handleDeleteAnswer,


### PR DESCRIPTION
## #️⃣ 이슈

- close #216 

## 📝 작업 내용
답변페이지에서, 질문을 개별로 삭제할 수 있는 기능을 만들었습니다.

## 📸 결과물
<img width="442" alt="image" src="https://github.com/user-attachments/assets/2d4fa569-684b-4d9a-b2fd-4abc55dd0c81" />

## 👩‍💻 공유 포인트 및 논의 사항
- 삭제가 두개가 있어서 명확하게 '질문삭제','답변삭제'로 이름을 변경해두었어요 (케밥메뉴)