### PR TITLE
Feat(#222): 라우터로 상세페이지 접근시 loader로 인한 로딩 ui보여주기

### DIFF
--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -1,8 +1,12 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useNavigation } from "react-router-dom";
+import { Loading } from "./Loding";
 
 export function Layout() {
+  const navigation = useNavigation();
+
   return (
     <>
+      {navigation.state === "loading" && <Loading />}
       <Outlet />
     </>
   );

--- a/src/components/Layout/Loading.module.css
+++ b/src/components/Layout/Loading.module.css
@@ -1,0 +1,32 @@
+.loading {
+  position: fixed;
+  z-index: 1000;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 5px solid var(--color-white);
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Layout/Loding.jsx
+++ b/src/components/Layout/Loding.jsx
@@ -1,0 +1,11 @@
+import { createPortal } from "react-dom";
+import styles from "./Loading.module.css";
+
+export function Loading() {
+  return createPortal(
+    <div className={styles.loading}>
+      <div className={styles.spinner}></div>
+    </div>,
+    document.querySelector("#root"),
+  );
+}


### PR DESCRIPTION
## #️⃣ 이슈

- close #222 

## 📝 작업 내용
새로고침이나, url직접접근에서는 hydrate fallback ui로 로딩을 구현했고
앱내에서 라우트 이동시에 상세페이지 접근할때, loader에서 데이터를 받는동안 화면이 멈춘듯하게 보이는 부분을
로딩ui추가로 개선했습니다.

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
