### PR TITLE
Refactor(#224) 피드 리스트 페이지헤더  반응형 수정

### DIFF
--- a/src/components/Button/LinkButton.module.css
+++ b/src/components/Button/LinkButton.module.css
@@ -11,14 +11,7 @@
   background-color: var(--color-primary-100);
   border: 1px solid var(--color-primary-400);
 }
-/* responsive state */
-.responsive {
-  @media (max-width: 787px) {
-    padding: 0.8rem 1.2rem;
-    height: 3.4rem;
-    font-size: var(--font-size-sm);
-  }
-}
+
 /* size */
 .md {
   padding: 1.2rem 2.4rem;
@@ -73,4 +66,12 @@
   background-color: var(--color-primary-300);
   border: none;
   cursor: not-allowed;
+}
+/* responsive state */
+.responsive {
+  @media (max-width: 787px) {
+    padding: 0.8rem 1.2rem;
+    height: 3.4rem;
+    font-size: var(--font-size-sm);
+  }
 }

--- a/src/pages/post/components/PostListHeader.jsx
+++ b/src/pages/post/components/PostListHeader.jsx
@@ -28,7 +28,7 @@ export default function PostListHeader() {
             <img src={logo} alt="오픈마인드 로고" />
           </Link>
         </div>
-        <LinkButton onClick={handleClick}>
+        <LinkButton onClick={handleClick} responsive={true}>
           답변하러 가기
           <Icon name="arrowRight" size={18}></Icon>
         </LinkButton>

--- a/src/pages/post/components/PostListHeader.module.css
+++ b/src/pages/post/components/PostListHeader.module.css
@@ -1,19 +1,32 @@
 .header__container {
   display: flex;
   flex-direction: column;
-  margin: 0px auto;
   justify-content: center;
   align-items: center;
   font-size: var(--font-size-h1);
-  max-width: 940px;
+  max-width: 100.4rem; /* 최대 너비 */
+  margin: 0 auto; /* 중앙 정렬 */
+  padding: 0 3.2rem; /* 좌우 여백 */
+  @media (width < 1004px) {
+    padding: 0 5rem;
+  }
+  @media (width < 662px) {
+    padding: 1.2rem 3.2rem;
+  }
 }
+
 .header__content {
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
   margin: 0px auto;
-  padding: 4rem;
+  padding: 4rem 0;
+
+  @media (width < 662px) {
+    flex-direction: column;
+    gap: 2rem;
+  }
 }
 
 .header__logo img {


### PR DESCRIPTION
## #️⃣ 이슈

- close #224 

## 📝 작업 내용
- 피그마 시안을 토대로 피드 리스트 페이지 헤더 반응형 수정 
- 버튼 responsive 동작이 안되는 것을 css 우선순위 조정을 통해 해결하였습니다.

## 📸 결과물
- PC
![image](https://github.com/user-attachments/assets/8a0f5f9b-8eef-4417-a01e-6fde0932c04f)
- Tablet
![image](https://github.com/user-attachments/assets/141a29cd-3f42-4871-ac0e-2dcc3faaa173)
- Mobile
![image](https://github.com/user-attachments/assets/4248d7c8-16c2-4d48-8ba9-3c3d8c05794c)

## 👩‍💻 공유 포인트 및 논의 사항
