### PR TITLE
Design(#247): 유저카드에 배경색 삽입

### DIFF
--- a/src/components/UserCard/UserCard.module.css
+++ b/src/components/UserCard/UserCard.module.css
@@ -6,6 +6,7 @@
   padding: 2rem;
   border: 0.1rem solid var(--color-gray-400);
   border-radius: var(--border-radius-lg);
+  background-color: var(--color-white);
 }
 
 .card:hover {


### PR DESCRIPTION
## #️⃣ 이슈

- close #247 

## 📝 작업 내용
 - 유저카드 배경색을 추가했습니다.

## 📸 결과물
<img width="1428" alt="스크린샷 2024-12-19 오전 11 37 52" src="https://github.com/user-attachments/assets/89a3a42d-de2e-442f-ac3d-cf0ffac854ba" />
