### PR TITLE
Fix(#265): 리액션 및 답변수정 사용자 경험 개선

### DIFF
--- a/src/components/FeedCard/AnswerForm.jsx
+++ b/src/components/FeedCard/AnswerForm.jsx
@@ -12,10 +12,12 @@ export function AnswerForm({
   isPending,
 }) {
   const [value, setValue] = useState(initialValue);
+  const isModified = initialValue !== value;
 
   async function handleSubmit(e) {
     e.preventDefault();
 
+    if (!isModified) return;
     if (!value.trim()) return Notify({ type: "error", message: "한글자 이상 입력해주세요" });
 
     onSubmit({ questionId, answerId, content: value });
@@ -42,7 +44,7 @@ export function AnswerForm({
           color="secondary"
           type="submit"
           className={styles.button}
-          disabled={!value || isPending}
+          disabled={!isModified || !value || isPending}
         >
           {initialValue ? "수정" : "작성"}
         </LinkButton>

--- a/src/pages/post/components/useQuestion.js
+++ b/src/pages/post/components/useQuestion.js
@@ -75,22 +75,6 @@ export default function useQuestion(subjectId) {
     onError: (error, _, context) => {
       queryClient.setQueriesData(["questions", subjectId], context.prevData);
     },
-    onSuccess: async (data) => {
-      // 성공하면서 받아온 데이터로 바꿔치기
-      queryClient.setQueriesData(["questions", subjectId], (prev) => {
-        if (!prev) return prev;
-
-        const newData = {
-          ...prev,
-          pages: prev.pages.map((page) => ({
-            ...page,
-            results: page.results.map((item) => (item.id === data.id ? data : item)),
-          })),
-        };
-
-        return newData;
-      });
-    },
   });
 
   const isPending = create.isPending || remove.isPending || reaction.isPending;


### PR DESCRIPTION
## #️⃣ 이슈

- close #265 

## 📝 작업 내용
- 질문의 좋아요, 싫어요 리액션의 낙관적 업데이트 개선
  - 기존에는 낙관적업데이트 이후에, 실제 데이터로 한번 더 교체를 해줬는데, 불필요해보여서 삭제 (오히려 더 방해가됨) 
- 답변 수정시 불필요한 요청 수정
  - 수정된 내용이 없을경우에 제출 버튼도 비활성화 및 제출시에도 한번 더 변경사항이 있는지 체크하도록 개선
  
## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
