### PR TITLE
Fix(#271): 질문카드 개선

### DIFF
--- a/src/components/FeedCard/Answer.jsx
+++ b/src/components/FeedCard/Answer.jsx
@@ -11,7 +11,9 @@ export const Answer = forwardRef(function Answer(
   const [isEdit, setIsEdit] = useState(false);
   const { id: answerId, createdAt, isRejected, content } = answer || {};
   const { name, imageSource } = user;
-  const isEditMode = mode === "answer" && isEdit;
+  const isEditMode = mode === "answer" && isEdit; // 수정모드 : '답변페이지'이면서 수정버튼을 클릭했을 경우
+  const isRejectedMode = isRejected && !isEditMode; // 거절모드 : 거절된상태이면서 수정모드가 아닐때
+  const isAnswerFormMode = isEditMode || !content; // 답변작성(수정)모드 : 수정버튼을 클릭했거나, 컨텐츠(답변)가 없을때
 
   // Answer 컴포넌트의 부모가 edit 모드를 컨트롤 할 수 있게 메서드 제공
   useImperativeHandle(ref, () => {
@@ -30,36 +32,22 @@ export const Answer = forwardRef(function Answer(
   }
 
   function renderAnswerContent() {
-    // 거절상태일 경우
-    if (isRejected && !isEditMode) {
+    // 거절모드
+    if (isRejectedMode) {
       return <div className={styles.reject}>답변 거절</div>;
     }
 
-    // 수정하기를 누를 경우
-    if (isEditMode) {
-      return (
-        <AnswerForm
-          initialValue={content}
-          questionId={questionId}
-          answerId={answerId}
-          onSubmit={onUpdateAnswer}
-          onCancel={handleCancel}
-          isPending={isPending}
-        />
-      );
-    }
-
-    // 컨텐츠가 있으면 컨텐츠 노출, 없으면 작성폼 노출
-    return (
-      content || (
-        <AnswerForm
-          questionId={questionId}
-          answerId={answerId}
-          onSubmit={onCreateAnswer}
-          onCancel={handleCancel}
-          isPending={isPending}
-        />
-      )
+    return isAnswerFormMode ? (
+      <AnswerForm
+        initialValue={content}
+        questionId={questionId}
+        answerId={answerId}
+        onSubmit={isEditMode ? onUpdateAnswer : onCreateAnswer}
+        onCancel={handleCancel}
+        isPending={isPending}
+      />
+    ) : (
+      content
     );
   }
 

--- a/src/components/FeedCard/FeedCard.jsx
+++ b/src/components/FeedCard/FeedCard.jsx
@@ -101,7 +101,11 @@ export function FeedCard({
             <MoreMenu.Item icon="reject" onClick={handleRejectAnswer} disabled={answer?.isRejected}>
               거절하기
             </MoreMenu.Item>
-            <MoreMenu.Item icon="edit" onClick={() => answerRef.current.openEdit()}>
+            <MoreMenu.Item
+              icon="edit"
+              onClick={() => answerRef.current.openEdit()}
+              disabled={!answer}
+            >
               수정하기
             </MoreMenu.Item>
             <MoreMenu.Item icon="close" onClick={handleRemoveAnswer} disabled={!answer}>

--- a/src/components/Toast/Toast.jsx
+++ b/src/components/Toast/Toast.jsx
@@ -19,22 +19,22 @@ export function Toast() {
   );
 }
 
-export function Notify(data) {
+export function Notify(data, options) {
   if (!data || !data.message) {
     return null;
   }
 
   switch (data.type) {
     case "success":
-      toast.success(data.message);
+      toast.success(data.message, options);
       break;
     case "error":
-      toast.error(data.message);
+      toast.error(data.message, options);
       break;
     case "info":
-      toast.info(data.message);
+      toast.info(data.message, options);
       break;
     default:
-      toast(data.message);
+      toast(data.message, options);
   }
 }

--- a/src/pages/post/PostAnswerPage.jsx
+++ b/src/pages/post/PostAnswerPage.jsx
@@ -1,4 +1,4 @@
-import { useParams, useRouteLoaderData } from "react-router-dom";
+import { useNavigate, useParams, useRouteLoaderData } from "react-router-dom";
 import useQuestions from "./components/useQuestions";
 import {
   FeedDeleteButton,
@@ -13,6 +13,7 @@ import { Notify } from "@components/Toast";
 
 export default function PostAnswerPage() {
   const { id } = useParams();
+  const navigate = useNavigate();
 
   // 피드 정보 (loader 데이터)
   const userInfo = useRouteLoaderData("post");
@@ -35,10 +36,15 @@ export default function PostAnswerPage() {
 
     try {
       await removeFeed(id);
-      Notify({ type: "success", message: "피드를 삭제했습니다." });
-      setTimeout(() => {
-        window.location.replace("/");
-      }, 800);
+      Notify(
+        { type: "success", message: "피드를 삭제했습니다." },
+        {
+          onClose: () => {
+            navigate("/");
+            window.location.reload(); // context에서 setFeeds를 하지않고 앱을 다시 마운팅 (protected router 때문에)
+          },
+        },
+      );
     } catch (error) {
       console.error(error);
       Notify({ type: "error", message: "문제가 생겨 삭제를 실패했습니다." });

--- a/src/pages/post/components/useAnswer.js
+++ b/src/pages/post/components/useAnswer.js
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Notify } from "@components/Toast";
 import { createAnswer, deleteAnswer, updateAnswer } from "@service/Answer";
 
 export default function useAnswer(subjectId) {
@@ -41,7 +40,7 @@ export default function useAnswer(subjectId) {
 
   const remove = useMutation({
     mutationFn: ({ answerId }) => {
-      if (!answerId) return Notify({ type: "error", message: "삭제할 내용이 없습니다." });
+      if (!answerId) return;
       return deleteAnswer(answerId);
     },
     onSuccess: (_, { questionId }) => {

--- a/src/pages/post/components/useAnswer.js
+++ b/src/pages/post/components/useAnswer.js
@@ -6,7 +6,7 @@ export default function useAnswer(subjectId) {
   const queryClient = useQueryClient();
 
   function updateCacheData(questionId, updateFunc) {
-    queryClient.setQueriesData(["questions", subjectId], (prev) => {
+    queryClient.setQueryData(["questions", subjectId], (prev) => {
       if (!prev) return prev;
 
       const newData = {

--- a/src/pages/post/components/useAnswer.js
+++ b/src/pages/post/components/useAnswer.js
@@ -57,10 +57,8 @@ export default function useAnswer(subjectId) {
   const reject = useMutation({
     mutationFn: ({ questionId, answerId, content, isRejected }) => {
       if (answerId) {
-        console.log("답변있는데 거절");
         return updateAnswer(answerId, content, isRejected);
       } else {
-        console.log("답변없는데 거절");
         return createAnswer(questionId, content, isRejected);
       }
     },

--- a/src/pages/post/components/useQuestion.js
+++ b/src/pages/post/components/useQuestion.js
@@ -39,6 +39,7 @@ export default function useQuestion(subjectId) {
           ...prev,
           pages: prev.pages.map((page) => ({
             ...page,
+            count: page.count - 1,
             results: page.results.filter((item) => item.id !== questionId),
           })),
         };

--- a/src/pages/post/components/useQuestion.js
+++ b/src/pages/post/components/useQuestion.js
@@ -7,7 +7,7 @@ export default function useQuestion(subjectId) {
   const create = useMutation({
     mutationFn: ({ content }) => createQuestion(subjectId, content),
     onSuccess: (data, { subjectId }) => {
-      queryClient.setQueriesData(["questions", subjectId], (prev) => {
+      queryClient.setQueryData(["questions", subjectId], (prev) => {
         if (!prev) return prev;
 
         const newData = {
@@ -32,7 +32,7 @@ export default function useQuestion(subjectId) {
   const remove = useMutation({
     mutationFn: ({ questionId }) => deleteQuestion(questionId),
     onSuccess: (_, { questionId }) => {
-      queryClient.setQueriesData(["questions", subjectId], (prev) => {
+      queryClient.setQueryData(["questions", subjectId], (prev) => {
         if (!prev) return prev;
 
         const newData = {
@@ -56,9 +56,9 @@ export default function useQuestion(subjectId) {
       const prevData = queryClient.getQueriesData(["questions", subjectId]);
 
       // optimistic update (기존 데이터 이용해서 ui바로 업데이트)
-      queryClient.setQueriesData(["questions", subjectId], (prev) => {
+      queryClient.setQueryData(["questions", subjectId], (prev) => {
         if (!prev) return prev;
-
+        console.log(prev);
         const newData = {
           ...prev,
           pages: prev.pages.map((page) => ({
@@ -74,7 +74,7 @@ export default function useQuestion(subjectId) {
       return { prevData };
     },
     onError: (error, _, context) => {
-      queryClient.setQueriesData(["questions", subjectId], context.prevData);
+      queryClient.setQueryData(["questions", subjectId], context.prevData);
     },
   });
 

--- a/src/pages/post/components/useQuestion.js
+++ b/src/pages/post/components/useQuestion.js
@@ -6,7 +6,7 @@ export default function useQuestion(subjectId) {
 
   const create = useMutation({
     mutationFn: ({ content }) => createQuestion(subjectId, content),
-    onSuccess: async (data, { subjectId }) => {
+    onSuccess: (data, { subjectId }) => {
       queryClient.setQueriesData(["questions", subjectId], (prev) => {
         if (!prev) return prev;
 
@@ -51,7 +51,7 @@ export default function useQuestion(subjectId) {
 
   const reaction = useMutation({
     mutationFn: ({ questionId, type }) => addQuestionReaction(questionId, type),
-    onMutate: async ({ questionId, type }) => {
+    onMutate: ({ questionId, type }) => {
       // 에러시 원복 데이터 생성
       const prevData = queryClient.getQueriesData(["questions", subjectId]);
 

--- a/src/pages/post/components/useQuestion.js
+++ b/src/pages/post/components/useQuestion.js
@@ -6,7 +6,7 @@ export default function useQuestion(subjectId) {
 
   const create = useMutation({
     mutationFn: ({ content }) => createQuestion(subjectId, content),
-    onSuccess: (data, { subjectId }) => {
+    onSuccess: (data) => {
       queryClient.setQueryData(["questions", subjectId], (prev) => {
         if (!prev) return prev;
 
@@ -58,7 +58,7 @@ export default function useQuestion(subjectId) {
       // optimistic update (기존 데이터 이용해서 ui바로 업데이트)
       queryClient.setQueryData(["questions", subjectId], (prev) => {
         if (!prev) return prev;
-        console.log(prev);
+
         const newData = {
           ...prev,
           pages: prev.pages.map((page) => ({


### PR DESCRIPTION
## #️⃣ 이슈

- close #271 

## 📝 작업 내용
- 질문 개별삭제후, 전체 질문갯수가 업데이트 안되는 현상 수정
- 질문의 케밥메뉴에 수정이 불가능한 상태 (미답변)이면 버튼 비활성화 추가
- 리액트쿼리 setQueriesData 수정 -> setQueryData : 공부를 더 해보니 이게 맞는것 같네요
- 불필요한 코드 삭제

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
