### PR TITLE
Fix(#286): 모달 메소드 추가 (강제 스크롤 0으로 복구하면서 닫히는 메소드 추가)

### DIFF
--- a/src/components/FeedCard/QuestionForm.jsx
+++ b/src/components/FeedCard/QuestionForm.jsx
@@ -22,8 +22,7 @@ export function QuestionForm({ feedOwner, onSubmit, isPending }) {
     try {
       await onSubmit({ content });
       Notify({ type: "success", message: MESSAGES.QUESTION.SUCCESS.CREATE });
-      modalRef.current.close();
-      window.scrollTo(0, 0);
+      modalRef.current.closeAndScrollTop();
     } catch (error) {
       console.log(error);
       Notify({ type: "error", message: MESSAGES.QUESTION.ERROR.CREATE });

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -48,11 +48,11 @@ export const Modal = forwardRef(function Modal({ title, icon, children }, ref) {
    * @type {boolean}
    */
   const [isOpen, setIsOpen] = useState(false);
-
+  const [forceScrollTop, setForceScrollTop] = useState(false);
   /**
    * 모달이나 특정 UI 요소가 열릴 때 스크롤을 잠그는 커스텀 훅입니다.
    */
-  usePreventScroll(isOpen);
+  usePreventScroll(isOpen, forceScrollTop);
 
   /**
    * 부모 컴포넌트에게 open과 close 메서드를 전달하기 위한 useImperativeHandle 훅 사용
@@ -63,6 +63,10 @@ export const Modal = forwardRef(function Modal({ title, icon, children }, ref) {
         setIsOpen(true);
       },
       close() {
+        setIsOpen(false);
+      },
+      closeAndScrollTop() {
+        setForceScrollTop(true);
         setIsOpen(false);
       },
     };

--- a/src/components/Modal/usePreventScroll.js
+++ b/src/components/Modal/usePreventScroll.js
@@ -13,7 +13,7 @@ import { useRef, useEffect } from "react";
  * const [isOpen, setIsOpen] = useState(false);
  * usePreventScroll(isOpen); // 모달이 열릴 때 스크롤을 잠그고, 닫을 때 복원
  */
-const usePreventScroll = (isOpen) => {
+const usePreventScroll = (isOpen, forceScrollTop) => {
   const scrollPositionRef = useRef(0);
 
   useEffect(() => {
@@ -31,7 +31,7 @@ const usePreventScroll = (isOpen) => {
       document.body.style.width = "";
       document.body.style.top = "";
       document.body.style.overflowY = "";
-      window.scrollTo(0, scrollPositionRef.current); // 원래의 위치로 스크롤 복원
+      window.scrollTo(0, forceScrollTop ? 0 : scrollPositionRef.current); // 원래의 위치로 스크롤 복원
     }
 
     // 컴포넌트 언마운트 시 클린업 작업
@@ -45,7 +45,7 @@ const usePreventScroll = (isOpen) => {
         window.scrollTo(0, scrollPositionRef.current);
       }
     };
-  }, [isOpen]);
+  }, [isOpen, forceScrollTop]);
 };
 
 export default usePreventScroll;


### PR DESCRIPTION
## #️⃣ 이슈

- close #286 

## 📝 작업 내용
- 질문 작성시 상단으로 스크롤을 복구해야하는데, 모달의 스크롤 위치 기억과 충돌로 코드 개선
- 모달컴포넌트에 강제 스크롤 0으로 복구하면서 닫히는 메소드 추가
- 
## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
