### PR TITLE
Fix(#296): useParams의 id를 number타입으로 변환후 필요한곳에 전달하도록 변경

### DIFF
--- a/src/components/FeedCard/AnswerButton.jsx
+++ b/src/components/FeedCard/AnswerButton.jsx
@@ -4,15 +4,16 @@ import styles from "./AnswerButton.module.css";
 
 export function AnswerButton() {
   const { id } = useParams();
+  const subjectId = Number(id);
   const { hasFeed } = useFeed();
-  const isOwner = hasFeed(id);
+  const isOwner = hasFeed(subjectId);
   const isQuestionPage = useMatch("/post/:id"); // 분기 처리
 
   if (!isOwner || !isQuestionPage) return null;
 
   return (
     <div className={styles.controls}>
-      <Link to={`/post/${id}/answer`} className={styles.button}>
+      <Link to={`/post/${subjectId}/answer`} className={styles.button}>
         답변하러가기
       </Link>
     </div>

--- a/src/context/FeedContext.jsx
+++ b/src/context/FeedContext.jsx
@@ -37,7 +37,7 @@ export default function FeedContextProvider({ children }) {
     async (feedId) => {
       setIsLoading(true);
 
-      await deleteSubject(Number(feedId));
+      await deleteSubject(feedId);
       //setFeeds((prev) => prev.filter((feed) => feed.id !== Number(feedId)));
 
       // setFeeds가 리랜더를 유발해서 protect router가 한번더 체크됨
@@ -47,7 +47,7 @@ export default function FeedContextProvider({ children }) {
       // 사용자쪽에서 앱을 새로고침하도록 유도
       // (앱이 다시 실행되면서 컨텍스트가 다시 실행되어, 초기값으로 로컬스토리지값을 슴)
 
-      const data = feeds.filter((feed) => feed.id !== Number(feedId));
+      const data = feeds.filter((feed) => feed.id !== feedId);
       localStorage.setItem("feeds", JSON.stringify(data));
       setIsLoading(false);
     },
@@ -56,7 +56,7 @@ export default function FeedContextProvider({ children }) {
 
   const hasFeed = useCallback(
     (feedId) => {
-      return feeds.find((feed) => feed.id === Number(feedId));
+      return feeds.find((feed) => feed.id === feedId);
     },
     [feeds],
   );

--- a/src/pages/post/PostAnswerPage.jsx
+++ b/src/pages/post/PostAnswerPage.jsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams, useRouteLoaderData } from "react-router-dom";
+import { useParams, useRouteLoaderData } from "react-router-dom";
 import useQuestions from "./components/useQuestions";
 import {
   FeedDeleteButton,
@@ -14,14 +14,14 @@ import { MESSAGES } from "@constants/messages";
 
 export default function PostAnswerPage() {
   const { id } = useParams();
-  const navigate = useNavigate();
+  const subjectId = Number(id);
 
   // 피드 정보 (loader 데이터)
   const userInfo = useRouteLoaderData("post");
 
   // 질문리스트 패칭훅
   const { count, results, ref, error, isLoading, isFetchingNextPage } = useQuestions({
-    subjectId: id,
+    subjectId,
     itemPerPage: 6,
   });
 
@@ -30,13 +30,13 @@ export default function PostAnswerPage() {
     subjectHandler: { removeFeed },
     questionHandler,
     answerHandler,
-  } = useSubject(id);
+  } = useSubject(subjectId);
 
   async function handleDeleteSubject() {
     if (!confirm(MESSAGES.SUBJECT.CONFIRM)) return;
 
     try {
-      await removeFeed(id);
+      await removeFeed(subjectId);
       Notify(
         { type: "success", message: MESSAGES.SUBJECT.SUCCESS.DELETE },
         {

--- a/src/pages/post/PostDetailPage.jsx
+++ b/src/pages/post/PostDetailPage.jsx
@@ -14,13 +14,14 @@ import {
 
 export default function PostDetailPage() {
   const { id } = useParams();
+  const subjectId = Number(id);
 
   // 피드 정보 (loader 데이터)
   const userInfo = useRouteLoaderData("post");
 
   // 질문리스트 패칭훅
   const { count, results, ref, error, isLoading, isFetchingNextPage } = useQuestions({
-    subjectId: id,
+    subjectId,
     itemPerPage: 6,
   });
 
@@ -29,7 +30,7 @@ export default function PostDetailPage() {
     subjectHandler: { saveFeed },
     questionHandler,
     answerHandler,
-  } = useSubject(id);
+  } = useSubject(subjectId);
 
   // 피드 방문 로그 저장
   useEffect(() => {

--- a/src/pages/post/components/ProtectedRoute.jsx
+++ b/src/pages/post/components/ProtectedRoute.jsx
@@ -5,8 +5,9 @@ import { useEffect } from "react";
 import { Navigate, useParams } from "react-router-dom";
 export default function ProtectedRoute({ children }) {
   const { id } = useParams();
+  const subjectId = Number(id);
   const { hasFeed } = useFeed();
-  const hasAccess = hasFeed(id);
+  const hasAccess = hasFeed(subjectId);
   useEffect(() => {
     // useeffect는 비동기라서
     // Navigate 컴포넌트가 반환되더라도, 스케쥴링되어서 실행되는점을 이용


### PR DESCRIPTION
## #️⃣ 이슈

- close #296 

## 📝 작업 내용
주말에 리액트쿼리키에 대해서 조금더 공부하다가, 쿼리키로 params의 값을 쓸때 type이 다르면 안되는걸 알게되어서
긴급하게 수정했습니다.

- 기존에는 useparams에서 받아온 string 타입의 id를 바로 사용 (데이터와 비교를 해야할경우에만 숫자로 변환, 어차피 요청은 문자열로 되니 신경 안썻음)
- 그래도 정확한 쿼리키값을 위해서는 처음부터 데이터의 원래의 type과 동일하게 관리하는것이 맞다고 판단되어 number타입으로 미리 변환해서 프로젝트 내에서 사용하도록 변경

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
