### PR TITLE
Refactor(#298): 생성한 피드가 없을때 Notify컴포넌트 사용하여 없음을 알리는 기능 개선

### DIFF
--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -12,6 +12,7 @@ export const MESSAGES = {
       MAX_LENGTH: "이름은 12자 미만으로 입력해주세요.",
       EMPTY: "이름을 입력해주세요.",
     },
+    EMPTY: "생성한 피드가 없습니다.",
   },
   QUESTION: {
     CONFIRM: "정말 질문을 삭제할까요?",

--- a/src/pages/main/components/IntroForm.jsx
+++ b/src/pages/main/components/IntroForm.jsx
@@ -2,14 +2,29 @@ import { useRef } from "react";
 import { MyFeedsButton, MyFeeds } from "@components/MyFeeds";
 import MainPageInputForm from "./MainPageInputForm";
 import styles from "./IntroForm.module.css";
+import { useFeed } from "@context/FeedContext";
+import { Notify } from "@components/Toast";
+import { MESSAGES } from "@constants/messages";
 
 function IntroForm() {
   const myFeedsModalRef = useRef(null);
 
+  const { feeds } = useFeed();
+
+  console.log(feeds);
+
   return (
     <section className={styles.section}>
       <MainPageInputForm />
-      <MyFeedsButton onClick={() => myFeedsModalRef.current?.open()} />
+      <MyFeedsButton
+        onClick={() => {
+          if (feeds.length === 0) {
+            Notify({ type: "info", message: MESSAGES.SUBJECT.EMPTY });
+          } else {
+            myFeedsModalRef.current?.open();
+          }
+        }}
+      />
       <MyFeeds ref={myFeedsModalRef} />
     </section>
   );

--- a/src/pages/main/components/IntroForm.jsx
+++ b/src/pages/main/components/IntroForm.jsx
@@ -11,20 +11,18 @@ function IntroForm() {
 
   const { feeds } = useFeed();
 
-  console.log(feeds);
+  const handleMyFeedsClick = () => {
+    if (feeds.length === 0) {
+      Notify({ type: "info", message: MESSAGES.SUBJECT.EMPTY });
+    } else {
+      myFeedsModalRef.current?.open();
+    }
+  };
 
   return (
     <section className={styles.section}>
       <MainPageInputForm />
-      <MyFeedsButton
-        onClick={() => {
-          if (feeds.length === 0) {
-            Notify({ type: "info", message: MESSAGES.SUBJECT.EMPTY });
-          } else {
-            myFeedsModalRef.current?.open();
-          }
-        }}
-      />
+      <MyFeedsButton onClick={handleMyFeedsClick} />
       <MyFeeds ref={myFeedsModalRef} />
     </section>
   );


### PR DESCRIPTION
## #️⃣ 이슈

- close #298

## 📝 작업 내용
 - 사용자가 "이미 생성한 피드가 있나요?" 버튼을 눌렀을때 생성한 피드가 없으면 Notify가 나타나 없음을 알리는 기능.

## 📸 결과물

https://github.com/user-attachments/assets/0c6b98f0-7075-4302-a412-03a2f558b54b


## 👩‍💻 공유 포인트 및 논의 사항
 - feeds에 데이터가 없어야 정확하게 테스트할 수 있는데.. 제가 테스트하면서 작성한 피드들을 손으로도 다 삭제하고 api들어가서도 다 삭제했는데
 오류인지 뭔지 2개가 삭제가 안되더라고요?? 페이지 들어가면 에러페이지뜨고 api 들어가서 id로 찾아도 데이터 없다 뜨는데 이상하게 계속 남아 있더라고요. 로컬스토리지에 남아있는건지... 피드데이터가 없으신분이 한번 테스트해봐야 제대로 되는지 알 것 같습니다
