### PR TITLE
Fix: 다른 페이지에서 sharekakao(name) 안 바뀌는 이슈 해결

### DIFF
--- a/src/pages/post/components/PostDetailHeader.jsx
+++ b/src/pages/post/components/PostDetailHeader.jsx
@@ -15,8 +15,8 @@ export default function PostDetailHeader() {
     if (!window.Kakao.isInitialized()) {
       window.Kakao.init(import.meta.env.VITE_KAKAO_KEY);
       console.log("Kakao SDK initialized:", window.Kakao.isInitialized());
-      shareKakao(name);
     }
+    shareKakao(name);
   }, [name]);
 
   return (


### PR DESCRIPTION
## #️⃣ 이슈

- close #316

## 📝 작업 내용
카카오 sdk 탑재부분에 같이 들어가 있어서
다른 페이지 갔을 때 sharekakao(name)이 바뀌지 않는 이슈 해결

## 📸 결과물

## 👩‍💻 공유 포인트 및 논의 사항
